### PR TITLE
Welsh CS's not showing in View and Paycal info not always available

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
@@ -31,18 +31,6 @@ DECLARE @IsComplianceScheme bit;
         INNER JOIN [rpd].[Organisations] O ON S.OrganisationId = O.ExternalId
     WHERE S.SubmissionId = @SubmissionId;
 
-	--BEGIN TRY
-	--	IF OBJECT_ID('tempdb..#ProdCommentsRegulatorDecisions') IS NOT NULL
-	--	BEGIN
-	--		DROP TABLE #ProdCommentsRegulatorDecisions;
-	--	END;
-	--END TRY
-	--BEGIN CATCH
-	--	-- Log or handle the error
-	--	-- PRINT 'An error occurred while attempting to drop the table ##ProdCommentsRegulatorDecisions.';
-	--	-- PRINT ERROR_MESSAGE(); -- Print the error message for debugging purposes
-	--END CATCH;
-
     DECLARE @ProdCommentsSQL NVARCHAR(MAX);
 
 	SET @ProdCommentsSQL = N'
@@ -235,9 +223,10 @@ DECLARE @IsComplianceScheme bit;
 					,org.PartnerFileId AS PartnershipFileId
 					,org.PartnerBlobName AS PartnershipBlobName
 					,ROW_NUMBER() OVER (
-						PARTITION BY s.OrganisationId,
-						s.SubmissionPeriod
-						ORDER BY s.load_ts DESC -- mark latest submission synced from cosmos
+						PARTITION BY s.OrganisationId
+								     ,s.SubmissionPeriod
+									 ,s.ComplianceSchemeId
+						ORDER BY s.load_ts DESC
 					) AS RowNum
 				FROM
 					[rpd].[Submissions] AS s
@@ -439,10 +428,5 @@ DECLARE @IsComplianceScheme bit;
         INNER JOIN [rpd].[Persons] p ON p.UserId = u.Id
         INNER JOIN [rpd].[PersonOrganisationConnections] poc ON poc.PersonId = p.Id
         INNER JOIN [rpd].[ServiceRoles] sr ON sr.Id = poc.PersonRoleId;
-
-	--IF OBJECT_ID('tempdb..##ProdCommentsRegulatorDecisions') IS NOT NULL
-    --BEGIN
-	--DROP TABLE ##ProdCommentsRegulatorDecisions;
-	--END
 END;
 GO

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/filter-and-paginate-organisation-registration-summaries.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/filter-and-paginate-organisation-registration-summaries.sql
@@ -17,203 +17,273 @@ create proc [dbo].[sp_FilterAndPaginateOrganisationRegistrationSummaries]
 AS
 begin
 	SET NOCOUNT ON;
-WITH
-    RequiredApplicationsByStatusCTE
-    AS
-    (
-        SELECT
-            *
-        FROM
-            dbo.[v_OrganisationRegistrationSummaries]
-        WHERE
-        (
-            NationId = @NationId OR @NationId = 0
-        )
-            AND EXISTS (
-            SELECT
-                1
-            FROM
-                STRING_SPLIT(@AppRefNumbersCommaSeparated, ',') AS AppReference
-            WHERE ApplicationReferenceNumber = LTRIM(RTRIM(AppReference.value))
-        )
-    )
-    ,InitialFilterCTE
-    AS
-    (
-        SELECT
-            *
-        FROM
-            dbo.[v_OrganisationRegistrationSummaries]
-        WHERE
-        (
-            NationId = @NationId OR @NationId = 0
-        )
-    )
-    ,NormalFilterCTE
-    AS
-    (
-        SELECT
-            *
-        FROM
-            InitialFilterCTE i
-        WHERE
-        (
+    IF EXISTS (
+		SELECT 1
+		FROM sys.columns
+		WHERE [name] = 'AppReferenceNumber' AND [object_id] = OBJECT_ID('rpd.Submissions')
+	)
+	BEGIN
+		CREATE TABLE #TempTable (
+			SubmissionId NVARCHAR(150) NULL,
+			OrganisationId NVARCHAR(150) NULL,
+			OrganisationInternalId INT NULL,
+			OrganisationName NVARCHAR(500) NULL,
+			UploadedOrganisationName NVARCHAR(500) NULL,
+			OrganisationReferenceNumber NVARCHAR(25) NULL,
+			SubmittedUserId NVARCHAR(150) NULL,
+			IsComplianceScheme BIT,
+			OrganisationType NVARCHAR(50) NULL,
+			ProducerSize NVARCHAR(50) NULL,
+			ApplicationReferenceNumber NVARCHAR(50) NULL,
+			RegistrationReferenceNumber NVARCHAR(50) NULL,
+			SubmittedDateTime NVARCHAR(50) NULL,
+			RelevantYear INT NULL,
+			SubmissionPeriod NVARCHAR(500) NULL,
+			IsLateSubmission BIT,
+			SubmissionStatus NVARCHAR(20) NULL,
+			StatusPendingDate NVARCHAR(50) NULL,
+			RegulatorDecisionDate NVARCHAR(50) NULL,
+			RegulatorUserId NVARCHAR(150) NULL,
+			ProducerCommentDate NVARCHAR(50) NULL,
+			ProducerSubmissionEventId NVARCHAR(150) NULL,
+			RegulatorSubmissionEventId NVARCHAR(150) NULL,
+			NationId INT NULL,
+			NationCode NVARCHAR(10) NULL
+		);
+		
+		exec dbo.sp_OrganisationRegistrationSummaries ;
+
+		WITH
+            NormalFilterCTE
+            AS
             (
+                SELECT
+					SubmissionId,
+					OrganisationId,
+					OrganisationInternalId,
+					OrganisationName,
+					OrganisationReferenceNumber,
+					OrganisationType,
+					SubmissionStatus,
+					StatusPendingDate,
+					ApplicationReferenceNumber,
+					RegistrationReferenceNumber,
+					RelevantYear,
+					SubmittedDateTime,
+					RegulatorDecisionDate,
+					ProducerCommentDate,
+					RegulatorUserId,
+					NationId,
+					NationCode
+			FROM #TempTable i
+            WHERE (
+				    NationId = @NationId
+                    OR @NationId = 0
+			)
+			AND (
+            EXISTS (
+                SELECT
+                        1
+                    FROM
+                        STRING_SPLIT(@AppRefNumbersCommaSeparated, ',') AS AppReference
+                    WHERE ApplicationReferenceNumber = LTRIM(RTRIM(AppReference.value))
+            )
+                    OR
+                    (
                 (
-                    LEN(ISNULL(@OrganisationNameCommaSeparated, '')) > 0
-            AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) > 0
-            AND EXISTS (
-                        SELECT
-                1
-            FROM
-                STRING_SPLIT(@OrganisationNameCommaSeparated, ',') AS Names
-            WHERE OrganisationName LIKE '%' + LTRIM(RTRIM(Names.value)) + '%'
-                    )
-            AND EXISTS (
-                        SELECT
-                1
-            FROM
-                STRING_SPLIT(@OrganisationReferenceCommaSeparated, ',') AS Reference
-            WHERE OrganisationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
-                OR ApplicationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
-                OR RegistrationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                    (
+                        (
+                            LEN(ISNULL(@OrganisationNameCommaSeparated, '')) > 0
+                    AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) > 0
+                    AND EXISTS (
+                                SELECT
+                        1
+                    FROM
+                        STRING_SPLIT(@OrganisationNameCommaSeparated, ',') AS Names
+                    WHERE OrganisationName LIKE '%' + LTRIM(RTRIM(Names.value)) + '%'
+                            )
+                    AND EXISTS (
+                                SELECT
+                        1
+                    FROM
+                        STRING_SPLIT(@OrganisationReferenceCommaSeparated, ',') AS Reference
+                    WHERE OrganisationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                        OR ApplicationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                        OR RegistrationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                            )
+                        ) -- Only OrganisationName specified
+                    OR (
+                            LEN(ISNULL(@OrganisationNameCommaSeparated, '')) > 0
+                    AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) = 0
+                    AND EXISTS (
+                                SELECT
+                        1
+                    FROM
+                        STRING_SPLIT(@OrganisationNameCommaSeparated, ',') AS Names
+                    WHERE OrganisationName LIKE '%' + LTRIM(RTRIM(Names.value)) + '%'
+                            )
+                        ) -- Only OrganisationReference specified
+                    OR (
+                            LEN(ISNULL(@OrganisationNameCommaSeparated, '')) = 0
+                    AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) > 0
+                    AND EXISTS (
+                                SELECT
+                        1
+                    FROM
+                        STRING_SPLIT(@OrganisationReferenceCommaSeparated, ',') AS Reference
+                    WHERE OrganisationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                        OR ApplicationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                        OR RegistrationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                            )
+                        )
+                    OR (
+                            LEN(ISNULL(@OrganisationNameCommaSeparated, '')) = 0
+                    AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) = 0
+                        )
                     )
                 )
-            -- Only OrganisationName specified
-            OR (
-                    LEN(ISNULL(@OrganisationNameCommaSeparated, '')) > 0
-            AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) = 0
-            AND EXISTS (
+                    AND (
+                    ISNULL(@OrganisationTypeCommaSeparated, '') = ''
+                    OR OrganisationType IN (
                         SELECT
-                1
-            FROM
-                STRING_SPLIT(@OrganisationNameCommaSeparated, ',') AS Names
-            WHERE OrganisationName LIKE '%' + LTRIM(RTRIM(Names.value)) + '%'
+                        TRIM(value)
+                    FROM
+                        STRING_SPLIT(@OrganisationTypeCommaSeparated, ',')
                     )
                 )
-            -- Only OrganisationReference specified
-            OR (
-                    LEN(ISNULL(@OrganisationNameCommaSeparated, '')) = 0
-            AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) > 0
-            AND EXISTS (
+                    AND (
+                    ISNULL(@SubmissionYearsCommaSeparated, '') = ''
+                    OR RelevantYear IN (
                         SELECT
-                1
-            FROM
-                STRING_SPLIT(@OrganisationReferenceCommaSeparated, ',') AS Reference
-            WHERE OrganisationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
-                OR ApplicationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
-                OR RegistrationReferenceNumber LIKE '%' + LTRIM(RTRIM(Reference.value)) + '%'
+                        TRIM(value)
+                    FROM
+                        STRING_SPLIT(
+                                CONCAT('2024,2025,', @SubmissionYearsCommaSeparated),
+                                ','
+                            )
                     )
                 )
-            OR (
-                    LEN(ISNULL(@OrganisationNameCommaSeparated, '')) = 0
-            AND LEN(ISNULL(@OrganisationReferenceCommaSeparated, '')) = 0
+                    AND (
+                    ISNULL(@StatusesCommaSeparated, '') = ''
+                    OR SubmissionStatus IN (
+                        SELECT
+                        TRIM(value)
+                    FROM
+                        STRING_SPLIT(@StatusesCommaSeparated, ',')
+                    )
                 )
             )
-        )
-            AND (ISNULL(@OrganisationTypeCommaSeparated, '') = '' OR OrganisationType IN
-            (SELECT
-                TRIM(value)
-            FROM
-                STRING_SPLIT(@OrganisationTypeCommaSeparated, ','))
-        )
-            AND (ISNULL(@SubmissionYearsCommaSeparated, '') = '' OR RelevantYear IN
-            (SELECT
-                TRIM(value)
-            FROM
-                STRING_SPLIT(CONCAT('2024,2025,', @SubmissionYearsCommaSeparated), ','))
-        )
-            AND (ISNULL(@StatusesCommaSeparated, '') = '' OR SubmissionStatus IN
-            (SELECT
-                TRIM(value)
-            FROM
-                STRING_SPLIT(@StatusesCommaSeparated, ','))
-        )
-    )
-    ,CombinedCTE
-    AS
-    (
-                    SELECT
-                *
-            FROM
-                NormalFilterCTE
-        UNION
-            SELECT
-                *
-            FROM
-                RequiredApplicationsByStatusCTE
-    )
-    ,SortedCTE
-    AS
-    (
+			) )
+			,SortedCTE
+				AS
+				(
+					SELECT
+						*
+					,ROW_NUMBER() OVER (
+					ORDER BY CASE
+						WHEN SubmissionStatus = 'Cancelled' THEN 6
+						WHEN SubmissionStatus = 'Refused' THEN 5
+						WHEN SubmissionStatus = 'Granted' THEN 4
+						WHEN SubmissionStatus = 'Queried' THEN 3
+						WHEN SubmissionStatus = 'Pending' THEN 2
+						WHEN SubmissionStatus = 'Updated' THEN 1
+					END,
+					SubmittedDateTime
+			) AS RowNum
+					FROM
+						NormalFilterCTE
+				)
+			,TotalRowsCTE
+				AS
+				(
+					SELECT
+						COUNT(*) AS TotalRows
+					FROM
+						SortedCTE
+				)
+			,PagedResultsCTE
+				AS
+				(
+					SELECT
+						*
+					,ROW_NUMBER() OVER (
+				ORDER BY RowNum
+			) AS PagedRowNum
+					FROM
+						SortedCTE
+				)
+			SELECT
+				SubmissionId
+				,OrganisationId
+				,OrganisationInternalId
+				,OrganisationType
+				,OrganisationName
+				,OrganisationReferenceNumber as OrganisationReference
+				,SubmissionStatus
+				,StatusPendingDate
+				,ApplicationReferenceNumber
+				,RegistrationReferenceNumber
+				,RelevantYear
+				,SubmittedDateTime
+				,RegulatorDecisionDate AS RegulatorCommentDate
+				,ProducerCommentDate
+				,RegulatorUserId
+				,NationId
+				,NationCode
+				,( SELECT COUNT(*) FROM SortedCTE ) AS TotalItems
+			FROM
+				PagedResultsCTE
+			WHERE PagedRowNum > (
+			@PageSize * (
+				LEAST(
+					@PageNumber,
+					CEILING(
+						(
+							SELECT
+					TotalRows
+				FROM
+					TotalRowsCTE
+						) / (1.0 * @PageSize)
+					)
+				) - 1
+			)
+		)
+		AND PagedRowNum <= @PageSize * LEAST(
+			@PageNumber,
+			CEILING(
+				(
+					SELECT
+					TotalRows
+				FROM
+					TotalRowsCTE
+				) / (1.0 * @PageSize)
+			)
+		)
+		ORDER BY RowNum;
+	END
+	ELSE
+	BEGIN
         SELECT
-            *
-            ,ROW_NUMBER() OVER (
-            ORDER BY
-                CASE
-                    WHEN SubmissionStatus = 'Cancelled' THEN 6
-                    WHEN SubmissionStatus = 'Refused' THEN 5
-                    WHEN SubmissionStatus = 'Granted' THEN 4
-                    WHEN SubmissionStatus = 'Queried' THEN 3
-                    WHEN SubmissionStatus = 'Pending' THEN 2
-                    WHEN SubmissionStatus = 'Updated' THEN 1
-                END,
-                SubmittedDateTime
-        ) AS RowNum
-        FROM
-            CombinedCTE
-    )
-    ,TotalRowsCTE
-    AS
-    (
-        SELECT
-            COUNT(*) AS TotalRows
-        FROM
-            SortedCTE
-    )
-    ,PagedResultsCTE
-    AS
-    (
-        SELECT
-            *
-            ,ROW_NUMBER() OVER (ORDER BY RowNum) AS PagedRowNum
-        FROM
-            SortedCTE
-    )
-SELECT
-    SubmissionId
-    ,OrganisationId
-    ,OrganisationInternalId
-    ,OrganisationType
-    ,OrganisationName
-    ,OrganisationReferenceNumber AS OrganisationReference
-    ,SubmissionStatus
-    ,StatusPendingDate
-    ,ApplicationReferenceNumber
-    ,RegistrationReferenceNumber
-    ,RelevantYear
-    ,SubmittedDateTime
-    ,RegulatorDecisionDate AS RegulatorCommentDate
-    ,ProducerCommentDate
-    ,RegulatorUserId
-    ,NationId
-    ,NationCode
-    ,(SELECT
-        COUNT(*)
-    FROM
-        SortedCTE) AS TotalItems
-FROM
-    PagedResultsCTE
-WHERE PagedRowNum > (@PageSize * (LEAST(@PageNumber, CEILING((SELECT
-        TotalRows
-    FROM
-        TotalRowsCTE) / (1.0 * @PageSize))) - 1))
-    AND PagedRowNum <= @PageSize * LEAST(@PageNumber, CEILING((SELECT
-        TotalRows
-    FROM
-        TotalRowsCTE) / (1.0 * @PageSize)))
-ORDER BY RowNum;
- 
-END
+            CAST(NULL AS UNIQUEIDENTIFIER) AS SubmissionId
+            ,CAST(NULL AS UNIQUEIDENTIFIER) AS OrganisationId
+            ,CAST(NULL AS Int) AS OrganisationInternalId
+            ,CAST(NULL AS NVARCHAR(50)) AS OrganisationType
+            ,CAST(NULL AS NVARCHAR(500)) AS OrganisationName
+            ,CAST(NULL AS NVARCHAR(25)) AS OrganisationReference
+            ,CAST(NULL AS NVARCHAR(20)) AS SubmissionStatus
+            ,CAST(NULL AS nvarchar(50)) AS StatusPendingDate
+            ,CAST(NULL AS NVARCHAR(50)) AS ApplicationReferenceNumber
+            ,CAST(NULL AS NVARCHAR(50)) AS RegistrationReferenceNumber
+            ,CAST(NULL AS INT) AS RelevantYear
+            ,CAST(NULL AS nvarchar(50)) AS SubmittedDateTime
+            ,CAST(NULL AS nvarchar(50)) AS RegulatorCommentDate
+            ,CAST(NULL AS nvarchar(50)) AS ProducerCommentDate
+            ,CAST(NULL AS UNIQUEIDENTIFIER) AS RegulatorUserId
+            ,CAST(NULL AS INT) AS NationId
+            ,CAST(NULL AS NVARCHAR(10)) AS NationCode
+            ,0 AS TotalItems
+        WHERE 1=0
+    END;
+END;
 
 GO

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_organisation_registration_summaries.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_organisation_registration_summaries.sql
@@ -1,0 +1,262 @@
+﻿IF EXISTS (SELECT 1 FROM sys.procedures WHERE object_id = OBJECT_ID(N'[dbo].[sp_OrganisationRegistrationSummaries]'))
+DROP PROCEDURE [dbo].[sp_OrganisationRegistrationSummaries];
+GO
+
+CREATE PROC [dbo].[sp_OrganisationRegistrationSummaries]
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+    -- Variable to hold the dynamically constructed SQL query
+    DECLARE @ProdCommentsSQL NVARCHAR(MAX);
+
+	SET @ProdCommentsSQL = N'
+	SELECT
+        decisions.SubmissionId,
+        decisions.SubmissionEventId AS SubmissionEventId,
+        decisions.Created AS DecisionDate,
+        decisions.Comments AS Comment,
+        decisions.UserId,
+		decisions.Type,
+        CASE
+            WHEN LTRIM(RTRIM(decisions.Decision)) = ''Accepted'' THEN ''Granted''
+            WHEN LTRIM(RTRIM(decisions.Decision)) = ''Rejected'' THEN ''Refused''
+            WHEN decisions.Decision IS NULL THEN ''Pending''
+            ELSE decisions.Decision
+        END AS SubmissionStatus,
+        NULL AS StatusPendingDate,
+        CASE 
+            WHEN decisions.Type = ''RegistrationApplicationSubmitted'' THEN 1 ELSE 0
+        END AS IsProducerComment,
+	';
+
+	IF EXISTS (
+		SELECT 1
+		FROM sys.columns
+		WHERE [name] = 'RegistrationReferenceNumber' AND [object_id] = OBJECT_ID('rpd.SubmissionEvents')
+	)
+	BEGIN
+		SET @ProdCommentsSQL = CONCAT(@ProdCommentsSQL, N'        decisions.RegistrationReferenceNumber AS RegistrationReferenceNumber,
+		')
+	END
+	ELSE
+	BEGIN
+		SET @ProdCommentsSQL = CONCAT(@ProdCommentsSQL, N'        NULL AS RegistrationReferenceNumber,
+		');
+	END;
+
+	SET @ProdCommentsSQL = CONCAT(@ProdCommentsSQL, N'
+            ROW_NUMBER() OVER (
+                PARTITION BY decisions.SubmissionId, decisions.Type
+                ORDER BY decisions.Created DESC
+            ) AS RowNum
+        INTO #ProdCommentsRegulatorDecisions
+        FROM rpd.SubmissionEvents AS decisions
+        WHERE decisions.Type IN (''RegistrationApplicationSubmitted'', ''RegulatorRegistrationDecision'');	');
+
+	EXEC sp_executesql @ProdCommentsSQL;
+
+	WITH ProdCommentsRegulatorDecisionsCTE as (
+			SELECT
+				SubmissionId
+				,SubmissionEventId
+				,DecisionDate
+				,Comment
+				,RegistrationReferenceNumber
+				,SubmissionStatus
+				,StatusPendingDate
+				,IsProducerComment
+				,UserId
+				,RowNum
+			FROM
+				#ProdCommentsRegulatorDecisions as decisions
+			WHERE decisions.Type IN ( 'RegistrationApplicationSubmitted', 'RegulatorRegistrationDecision')
+		)
+		,GrantedDecisionsCTE as (
+			SELECT *
+			FROM ProdCommentsRegulatorDecisionsCTE granteddecision
+			WHERE IsProducerComment = 0
+					AND SubmissionStatus = 'Granted'
+		)
+		,LatestOrganisationRegistrationSubmissionsCTE
+		AS
+		(
+			SELECT
+				a.*
+			FROM
+				(
+				SELECT
+					o.Name AS OrganisationName
+					,org.UploadOrgName as UploadedOrganisationName
+					,o.ReferenceNumber
+					,o.Id as OrganisationInternalId
+					,o.ExternalId as OrganisationId
+					,s.AppReferenceNumber AS ApplicationReferenceNumber
+					,granteddecision.RegistrationReferenceNumber
+					,granteddecision.SubmissionStatus
+					,granteddecision.DecisionDate as RegulatorDecisionDate
+					,granteddecision.UserId as RegulatorUserId
+            		,se.DecisionDate as ProducerCommentDate
+					,se.Comment as ProducerComment
+					,se.SubmissionEventId as ProducerSubmissionEventId
+					,granteddecision.SubmissionEventId as RegulatorSubmissionEventId
+					,s.SubmissionPeriod
+					,s.SubmissionId
+					,s.OrganisationId AS InternalOrgId
+					,se.DecisionDate AS SubmittedDateTime
+					,CASE 
+						WHEN cs.NationId IS NOT NULL THEN cs.NationId
+						ELSE
+						CASE UPPER(org.NationCode)
+							WHEN 'EN' THEN 1
+							WHEN 'NI' THEN 2
+							WHEN 'SC' THEN 3
+							WHEN 'WS' THEN 4
+							WHEN 'WA' THEN 4
+						 END
+					 END AS NationId
+					,CASE
+						WHEN cs.NationId IS NOT NULL THEN
+							CASE cs.NationId
+								WHEN 1 THEN 'GB-ENG'
+								WHEN 2 THEN 'GB-NIR'
+								WHEN 3 THEN 'GB-SCT'
+								WHEN 4 THEN 'GB-WLS'
+							END
+						ELSE
+						CASE UPPER(org.NationCode)
+							WHEN 'EN' THEN 'GB-ENG'
+							WHEN 'NI' THEN 'GB-NIR'
+							WHEN 'SC' THEN 'GB-SCT'
+							WHEN 'WS' THEN 'GB-WLS'
+							WHEN 'WA' THEN 'GB-WLS'
+						END
+					 END AS NationCode
+					,s.SubmissionType
+					,s.UserId AS SubmittedUserId
+					,CAST(
+						SUBSTRING(
+							s.SubmissionPeriod,
+							PATINDEX('%[0-9][0-9][0-9][0-9]%', s.SubmissionPeriod),
+							4
+						) AS INT
+					) AS RelevantYear
+					,CAST(
+						CASE
+							WHEN se.DecisionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
+											s.SubmissionPeriod,
+											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
+											4
+										)),4,1) THEN 1
+							ELSE 0
+						END AS BIT
+					) AS IsLateSubmission
+					,CASE UPPER(TRIM(org.organisationsize))
+						WHEN 'S' THEN 'Small'
+						WHEN 'L' THEN 'Large'
+					END as ProducerSize
+					,CASE WHEN s.ComplianceSchemeId is not null THEN 1 ELSE 0 END as IsComplianceScheme
+					,ROW_NUMBER() OVER (
+						PARTITION BY s.OrganisationId,
+						s.SubmissionPeriod, s.ComplianceSchemeId
+						ORDER BY s.load_ts DESC
+					) AS RowNum
+				FROM
+					[rpd].[Submissions] AS s
+					INNER JOIN [dbo].[v_UploadedRegistrationDataBySubmissionPeriod] org 
+						ON org.SubmittingExternalId = s.OrganisationId 
+						and org.SubmissionPeriod = s.SubmissionPeriod
+						and org.SubmissionId = s.SubmissionId
+					INNER JOIN [rpd].[Organisations] o on o.ExternalId = s.OrganisationId
+					LEFT JOIN [rpd].[ComplianceSchemes] cs on cs.ExternalId = s.ComplianceSchemeId 
+					LEFT JOIN GrantedDecisionsCTE granteddecision on granteddecision.SubmissionId = s.SubmissionId 
+					INNER JOIN ProdCommentsRegulatorDecisionsCTE se on se.SubmissionId = s.SubmissionId 
+						and se.IsProducerComment = 1
+				WHERE s.AppReferenceNumber IS NOT NULL
+					AND s.SubmissionType = 'Registration'
+					ANd s.IsSubmitted = 1
+			) AS a
+			WHERE a.RowNum = 1
+		)
+		,LatestRelatedRegulatorDecisionsCTE AS
+		(
+			select b.SubmissionId
+				,b.SubmissionEventId
+				,b.DecisionDate as RegulatorDecisionDate
+				,b.Comment as RegulatorComment
+				,b.RegistrationReferenceNumber
+				,b.SubmissionStatus
+				,b.StatusPendingDate
+				,b.UserId
+			from ProdCommentsRegulatorDecisionsCTE as b
+			where b.IsProducerComment = 0 and b.RowNum = 1
+		)
+		,AllRelatedProducerCommentEventsCTE
+		AS
+		(
+			SELECT
+				CONVERT(uniqueidentifier, c.SubmissionId) as SubmissionId
+				,c.SubmissionEventId
+				,c.Comment AS ProducerComment
+				,c.DecisionDate AS ProducerCommentDate
+			FROM
+				(
+				SELECT TOP 1
+					ProdCommentsRegulatorDecisionsCTE.SubmissionEventId
+					,ProdCommentsRegulatorDecisionsCTE.SubmissionId
+					,ProdCommentsRegulatorDecisionsCTE.Comment 
+					,ProdCommentsRegulatorDecisionsCTE.DecisionDate 
+				FROM LatestOrganisationRegistrationSubmissionsCTE 
+						LEFT JOIN ProdCommentsRegulatorDecisionsCTE 
+						ON ProdCommentsRegulatorDecisionsCTE.IsProducerComment = 1 
+						   AND ProdCommentsRegulatorDecisionsCTE.SubmissionId = LatestOrganisationRegistrationSubmissionsCTE.SubmissionId 
+				ORDER BY ProdCommentsRegulatorDecisionsCTE.DecisionDate desc
+			) AS c
+		)
+		,AllSubmissionsAndDecisionsAndCommentCTE
+		AS
+		(
+			SELECT DISTINCT
+				submissions.SubmissionId
+				,submissions.OrganisationId
+				,submissions.OrganisationInternalId
+				,submissions.OrganisationName
+				,submissions.UploadedOrganisationName
+				,submissions.ReferenceNumber as OrganisationReferenceNumber
+				,submissions.SubmittedUserId
+				,submissions.IsComplianceScheme
+				,CASE 
+					WHEN submissions.IsComplianceScheme = 1 THEN 'Compliance'
+					ELSE submissions.ProducerSize
+				END AS OrganisationType
+				,submissions.ProducerSize
+				,submissions.ApplicationReferenceNumber
+				,submissions.RegistrationReferenceNumber
+				,submissions.SubmittedDateTime
+				,submissions.RelevantYear
+				,submissions.SubmissionPeriod
+				,submissions.IsLateSubmission
+				,ISNULL(decisions.SubmissionStatus, 'Pending') as SubmissionStatus
+				,decisions.StatusPendingDate
+				,decisions.RegulatorDecisionDate
+				,decisions.UserId as RegulatorUserId
+				,ISNULL(submissions.ProducerCommentDate, producercomments.ProducerCommentDate) as ProducerCommentDate
+				,ISNULL(submissions.ProducerSubmissionEventId, producercomments.SubmissionEventId) as ProducerSubmissionEventId
+				,ISNULL(submissions.RegulatorSubmissionEventId, decisions.SubmissionEventId) AS RegulatorSubmissionEventId
+				,submissions.NationId
+				,submissions.NationCode
+			FROM
+				LatestOrganisationRegistrationSubmissionsCTE submissions
+				LEFT JOIN LatestRelatedRegulatorDecisionsCTE decisions
+					ON decisions.SubmissionId = submissions.SubmissionId
+				LEFT JOIN AllRelatedProducerCommentEventsCTE producercomments
+					ON producercomments.SubmissionId = submissions.SubmissionId
+		)
+	INSERT INTO #TempTable
+	SELECT
+		DISTINCT *
+	FROM
+		AllSubmissionsAndDecisionsAndCommentCTE submissions;
+END;
+
+GO

--- a/src/EPR.CommonDataService.Data/Scripts/Views/compliance-scheme-members.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/compliance-scheme-members.sql
@@ -6,118 +6,119 @@ WHERE object_id = OBJECT_ID(N'[dbo].[v_ComplianceSchemeMembers]')
 GO
 CREATE VIEW [dbo].[v_ComplianceSchemeMembers]
 AS WITH
-        AllComplianceOrgFilesCTE
-        as
-        (
-            SELECT distinct
-                c.[OrganisationId] as CSOExternalId
-                ,o.ReferenceNumber as CSOReference
-                ,CAST(SUBSTRING(c.SubmissionPeriod, PATINDEX('%[0-9][0-9][0-9][0-9]%', c.SubmissionPeriod), 4) AS INT) AS RelevantYear
-                ,c.submissionperiod
-                ,c.Created as SubmittedDate
-                , c.ComplianceSchemeId
-                ,c.[FileName]
-                ,c.created
-                ,CONVERT(DATETIME, Substring(c.[created], 1, 23)) as SortBy --For a given Organisation, in a given submission period, finding the most recently accepted org file based on the submission date--
-                ,Row_Number() Over(
-                    Partition by c.organisationid,
-                    c.submissionperiod
-                    order by CONVERT(DATETIME, Substring(c.[created], 1, 23)) desc
-                ) as RowNumber
-            FROM rpd.organisations o
-                INNER JOIN [rpd].[cosmos_file_metadata] c ON c.organisationid = o.externalid
-                    AND FileType = 'CompanyDetails'
-            WHERE o.IsComplianceScheme = 1
-        )
-        ,Accepted_CSO_org_files
-        AS
-        (
-            SELECT distinct
-                c.[OrganisationId] as ExternalId
-                ,o.[Id] as OrganisationId
-                ,c.[FileName]
-                ,c.[FileType]
-                ,c.SubmissionPeriod
-                ,c.created --For a given Organisation, in a given submission period, finding the most recently accepted Pom file based on the submission date--
-                ,Row_Number() Over(
-                Partition by c.organisationid,
-                c.submissionperiod
-                order by CONVERT(DATETIME, Substring(c.[created], 1, 23)) desc
-            ) as RowNumber
-            FROM rpd.organisations o
-                INNER JOIN [rpd].[cosmos_file_metadata] c ON c.organisationid = o.externalid
-                INNER JOIN [apps].[submissionevents] se ON Trim(se.fileid) = Trim(c.fileid)
-                    AND se.[type] = 'RegulatorRegistrationDecision'
-                    AND se.decision = 'Accepted'
-                    AND Trim(c.filetype) = 'CompanyDetails'
-        )
-        ,Latest_Accepted_CSO_Org_file
-        as
-        (
-            -- we don't need accepted Files, our journey is for the Regulator to Accept or Reject the files
-            --From the CTE retrieve the Filename of the identified file--
-            SELECT DISTINCT Filename
-                ,FileType
-                ,submissionperiod
-                ,created
-            FROM Accepted_CSO_org_files acof
-            WHERE acof.RowNumber = 1
-        )
-        ,Latest_CSO_Org_Files
-        as
-        (
-            SELECT DISTINCT
-                CSOExternalId
-                ,CSOReference
-                ,ComplianceSchemeId
-                ,FileName
-                ,RelevantYear
-                ,SubmissionPeriod
-                ,created as SubmittedDate
-            from AllComplianceOrgFilesCTE
-            where RowNumber = 1
-        ) -- retrieve Organisations that are created with that Compliance Org File
-        ,Unaccepted_MemberOrgsCTE
-        as
-        (
-            SELECT DISTINCT
-                CSOExternalId as CSOExternalId
-                ,CSOReference
-                ,organisation_id as OrganisationReference
-                ,o.ExternalId as OrganisationId
-                ,lcof.ComplianceSchemeId
-                ,submissionperiod
-                ,RelevantYear
-                ,SubmittedDate
-                ,CASE
-                    WHEN SubmittedDate > DATEFROMPARTS(RelevantYear, 4, 1) THEN 1
-                    ELSE 0
-                 END IsLateFeeApplicable
-                ,lcof.FileName
-            from [rpd].[CompanyDetails] cd
-                inner join Latest_CSO_Org_Files lcof on lcof.FileName = cd.FileName --inner join rpd.Organisations o on o.ReferenceNumber = cd.organisation_id
-                inner join rpd.organisations o on o.ReferenceNumber = cd.organisation_id
-        )
-        ,Accepted_MemberOrgsCTE
-        as
-        (
-            SELECT DISTINCT organisation_id as OrganisationId
-            from [rpd].[CompanyDetails] cd
-                inner join Latest_Accepted_CSO_Org_file laofc on laofc.FileName = cd.FileName
-                inner join [rpd].[Organisations] o on o.id = cd.organisation_id
-                    and o.IsComplianceScheme = 0
-        )
-    SELECT u.CSOExternalId
-          ,u.CSOReference
-          ,u.ComplianceSchemeId
-          ,u.OrganisationReference as ReferenceNumber
-          ,u.OrganisationId as ExternalId
-          ,u.SubmissionPeriod
-          ,u.RelevantYear
-          ,u.SubmittedDate
-          ,u.IsLateFeeApplicable
-          ,u.FileName
-    from Unaccepted_MemberOrgsCTE u
-        inner join rpd.organisations o on o.referencenumber = u.OrganisationReference
-    where o.IsComplianceScheme = 0;
- GO
+		AllComplianceOrgFilesCTE
+		as
+		(
+			SELECT distinct 
+				c.[OrganisationId] as CSOExternalId
+				,o.ReferenceNumber as CSOReference
+				,CAST(SUBSTRING(c.SubmissionPeriod, PATINDEX('%[0-9][0-9][0-9][0-9]%', c.SubmissionPeriod), 4) AS INT) AS RelevantYear
+				,c.submissionperiod
+				,c.Created as SubmittedDate
+				, c.ComplianceSchemeId
+				,c.[FileName]
+				,c.created
+				,CONVERT(DATETIME, Substring(c.[created], 1, 23)) as SortBy --For a given Organisation, in a given submission period, finding the most recently accepted org file based on the submission date--
+				,Row_Number() Over(
+					Partition by c.organisationid,
+					c.submissionperiod,
+					c.ComplianceSchemeId
+					order by CONVERT(DATETIME, Substring(c.[created], 1, 23)) desc
+				) as RowNumber
+			FROM rpd.organisations o
+				INNER JOIN [rpd].[cosmos_file_metadata] c ON c.organisationid = o.externalid
+					AND FileType = 'CompanyDetails'
+			WHERE o.IsComplianceScheme = 1
+		)
+		,Accepted_CSO_org_files
+		AS
+		(
+			SELECT distinct 
+				c.[OrganisationId] as ExternalId
+				,o.[Id] as OrganisationId
+				,c.[FileName]
+				,c.[FileType]
+				,c.SubmissionPeriod
+				,c.created --For a given Organisation, in a given submission period, finding the most recently accepted Pom file based on the submission date--
+				,Row_Number() Over(
+				Partition by c.organisationid,
+				c.submissionperiod
+				order by CONVERT(DATETIME, Substring(c.[created], 1, 23)) desc
+			) as RowNumber
+			FROM rpd.organisations o
+				INNER JOIN [rpd].[cosmos_file_metadata] c ON c.organisationid = o.externalid
+				INNER JOIN [rpd].[submissionevents] se ON Trim(se.fileid) = Trim(c.fileid)
+					AND se.[type] = 'RegulatorRegistrationDecision'
+					AND se.decision = 'Accepted'
+					AND Trim(c.filetype) = 'CompanyDetails'
+		)
+		,Latest_Accepted_CSO_Org_file
+		as
+		(
+			-- we don't need accepted Files, our journey is for the Regulator to Accept or Reject the files
+			--From the CTE retrieve the Filename of the identified file--
+			SELECT DISTINCT Filename
+				,FileType
+				,submissionperiod
+				,created
+			FROM Accepted_CSO_org_files acof
+			WHERE acof.RowNumber = 1
+		)
+		,Latest_CSO_Org_Files
+		as
+		(
+			SELECT DISTINCT 
+				CSOExternalId
+				,CSOReference
+				,ComplianceSchemeId
+				,FileName
+				,RelevantYear
+				,SubmissionPeriod
+				,created as SubmittedDate
+			from AllComplianceOrgFilesCTE
+			where RowNumber = 1
+		) -- retrieve Organisations that are created with that Compliance Org File
+		,Unaccepted_MemberOrgsCTE
+		as
+		(
+			SELECT DISTINCT 
+				CSOExternalId as CSOExternalId
+				,CSOReference
+				,organisation_id as OrganisationReference
+				,o.ExternalId as OrganisationId
+				,lcof.ComplianceSchemeId
+				,submissionperiod
+				,RelevantYear
+				,SubmittedDate
+				,CASE 
+					WHEN SubmittedDate > DATEFROMPARTS(RelevantYear, 4, 1) THEN 1
+					ELSE 0
+				 END IsLateFeeApplicable
+				,lcof.FileName
+			from [rpd].[CompanyDetails] cd
+				inner join Latest_CSO_Org_Files lcof on lcof.FileName = cd.FileName --inner join rpd.Organisations o on o.ReferenceNumber = cd.organisation_id
+				inner join rpd.organisations o on o.ReferenceNumber = cd.organisation_id
+		)
+		,Accepted_MemberOrgsCTE
+		as
+		(
+			SELECT DISTINCT organisation_id as OrganisationId
+			from [rpd].[CompanyDetails] cd
+				inner join Latest_Accepted_CSO_Org_file laofc on laofc.FileName = cd.FileName
+				inner join [rpd].[Organisations] o on o.id = cd.organisation_id
+					and o.IsComplianceScheme = 0
+		)
+	SELECT u.CSOExternalId
+		  ,u.CSOReference
+		  ,u.ComplianceSchemeId
+		  ,u.OrganisationReference as ReferenceNumber
+		  ,u.OrganisationId as ExternalId
+		  ,u.SubmissionPeriod
+		  ,u.RelevantYear
+		  ,u.SubmittedDate
+		  ,u.IsLateFeeApplicable
+		  ,u.FileName
+	from Unaccepted_MemberOrgsCTE u
+		inner join rpd.organisations o on o.referencenumber = u.OrganisationReference
+	where o.IsComplianceScheme = 0;
+GO

--- a/src/EPR.CommonDataService.Data/Scripts/Views/uploaded-registration-data-by-submission-period.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/uploaded-registration-data-by-submission-period.sql
@@ -25,7 +25,7 @@ WITH
 			,CONVERT( BIT, CASE WHEN ComplianceSchemeId IS NULL THEN 0 ELSE 1 END) as IsComplianceUpload
 			,Created
 			,STRING_AGG(FileType, ',') AS FileTypes
-			,row_number() OVER (partition BY organisationid, SubmissionPeriod ORDER BY created DESC) AS RowNum
+			,row_number() OVER (partition BY organisationid, SubmissionPeriod, ComplianceSchemeId ORDER BY created DESC) AS RowNum
             FROM
                 rpd.cosmos_file_metadata
             WHERE SubmissionType = 'Registration'
@@ -133,4 +133,5 @@ SELECT
     *
 FROM
     companyandfiledetails;
+    
 GO


### PR DESCRIPTION
### Actual Problem  
Multiple CS's from 1 org are not being seen in the end results.   An org presenting multiple CS submissions would have only the most recent submission visible.   The Ticket mentions Welsh as this is the first example of test-data that demonstrates the problem.

### Cause
Supporting views and the primary view were not including the ComplianceSchemeId in the grouping of duplicate rows to be sorted and selected by most-recent-date. 

### Solution
Adjusted supporting views and primary View and SP to ensure row-grouping of mutliple-rowsets includes the compliance Id for uploaded data, compliance-scheme extraction and submission details.
