### PR TITLE
Relocate code execution of GetLastSyncTime to a Stored Procedure

### DIFF
--- a/src/EPR.CommonDataService.Core.UnitTests/Services/SubmissionsEventServiceTests.cs
+++ b/src/EPR.CommonDataService.Core.UnitTests/Services/SubmissionsEventServiceTests.cs
@@ -1,41 +1,84 @@
+using AutoFixture;
 using EPR.CommonDataService.Core.Models;
 using EPR.CommonDataService.Core.Services;
 using EPR.CommonDataService.Core.UnitTests.TestHelpers;
+using EPR.CommonDataService.Data.Entities;
 using EPR.CommonDataService.Data.Infrastructure;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace EPR.CommonDataService.Core.UnitTests.Services;
 
 [TestClass]
 public class SubmissionEventServiceTests
 {
-    private SynapseContext _synapseContext = null!;
     private SubmissionEventService _sut = null!;
 
-    private DbContextOptions<SynapseContext> _dbContextOptions = null!;
+    private Fixture _fixture = null!;
+    private Mock<SynapseContext> _mockSynapseContext = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _dbContextOptions = new DbContextOptionsBuilder<SynapseContext>()
-            .UseInMemoryDatabase("SynapseTests")
-            .ConfigureWarnings(builder => builder.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-        _synapseContext = new SynapseContext(_dbContextOptions);
-        SubmissionEventTestHelper.SetupDatabaseForSubmissionEvents(_synapseContext);
+        var mockLogger = new Mock<ILogger<SubmissionsService>>();
+        _fixture = new Fixture();
+        _mockSynapseContext = new Mock<SynapseContext>();
 
-        _sut = new SubmissionEventService(_synapseContext);
+        _sut = new SubmissionEventService(_mockSynapseContext.Object, mockLogger.Object);
     }
 
     [TestMethod]
     public async Task When_Last_Sync_Time_Is_Requested_Then_Return_Date_Time()
     {
+        var lastSyncExpected = _fixture
+            .Build<SubmissionEventsLastSync>()
+            .With(x => x.LastSyncTime, DateTime.UtcNow.AddHours(-1))
+            .CreateMany(1).ToList();
+
+        _mockSynapseContext
+            .Setup(x => x.RunSpCommandAsync<SubmissionEventsLastSync>(
+                It.IsAny<string>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<string>(),
+                It.IsAny<SqlParameter[]>()
+            ))
+            .ReturnsAsync(lastSyncExpected).Verifiable();
+
         //Act
         var result = await _sut.GetLastSyncTimeAsync();
 
         //Assert
         result.Should().NotBeNull();
         result.Should().BeOfType<SubmissionEventsLastSync>();
+    }
+
+    [TestMethod]
+    public async Task When_Last_Sync_Time_Returns_No_Data_Throws_Exception()
+    {
+        var lastSyncExpected = _fixture
+            .Build<SubmissionEventsLastSync>()
+            .With(x => x.LastSyncTime, DateTime.UtcNow.AddHours(-1))
+            .CreateMany(0).ToList();
+
+        _mockSynapseContext
+            .Setup(x => x.RunSpCommandAsync<SubmissionEventsLastSync>(
+                It.IsAny<string>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<string>(),
+                It.IsAny<SqlParameter[]>()
+            ))
+            .ReturnsAsync(lastSyncExpected).Verifiable();
+
+        //Act
+        var ex = await Assert.ThrowsExceptionAsync<Exception>(async () =>
+        {
+            await _sut.GetLastSyncTimeAsync();
+        });
+
+        //Assert
+        StringAssert.Contains(ex.Message, "No data found from GetLastSyncTime");
     }
 }

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/get_last_sync_time.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/get_last_sync_time.sql
@@ -1,0 +1,11 @@
+﻿IF EXISTS (SELECT 1 FROM sys.procedures WHERE object_id = OBJECT_ID(N'[dbo].[GetLastSyncTime]'))
+DROP PROCEDURE [dbo].[GetLastSyncTime];
+GO
+
+create procedure [dbo].[GetLastSyncTime]
+AS
+BEGIN
+    SELECT MAX(load_ts) as LastSyncTime
+    from apps.SubmissionEvents
+END
+


### PR DESCRIPTION
To overcome an inherited issue, we have located LastSyncTime to an SP. The problem is that entity framework was being used with the MAX aggregator which is deeply inefficient.

The SubmissionEvent Service has been modified to call a new stored procedure.