### PR TITLE
Rel 8.2 Repairs. Late Fee Calculation, Lost Queried Submissions, Submitting Person issues are repaired, String_Agg, CSO Count

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Functions/fn_get-uploaded-organisation-details.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Functions/fn_get-uploaded-organisation-details.sql
@@ -6,6 +6,13 @@ WHERE object_id = OBJECT_ID(N'[dbo].[fn_GetUploadedOrganisationDetails]'))
 DROP FUNCTION [dbo].[fn_GetUploadedOrganisationDetails];
 GO
 
+/****** Object:  UserDefinedFunction [dbo].[fn_GetUploadedOrganisationDetails]    Script Date: 31/03/2025 11:20:16 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
 CREATE FUNCTION [dbo].[fn_GetUploadedOrganisationDetails] (@OrganisationUUID [nvarchar](40),@SubmissionPeriod [nvarchar](25)) RETURNS TABLE
 AS
 RETURN (	   
@@ -25,14 +32,12 @@ WITH
 			,RegistrationSetId
 			,ComplianceSchemeId
 			,Created
-			,STRING_AGG(FileType, ',') AS FileTypes
-			,row_number() OVER (partition BY organisationid, SubmissionPeriod, ComplianceSchemeId ORDER BY created desc, load_ts DESC) AS RowNum
+			,row_number() OVER (partition BY organisationid, SubmissionPeriod, ComplianceSchemeId ORDER BY created desc) AS RowNum
             FROM
                 rpd.cosmos_file_metadata
             WHERE SubmissionType = 'Registration'
                 AND (ISNULL(@SubmissionPeriod,'') = '' OR SubmissionPeriod = @SubmissionPeriod)
                 AND (ISNULL(@OrganisationUUID,'') = '' OR organisationid = @OrganisationUUID)
-            GROUP BY organisationid, submissionperiod, complianceschemeid, registrationsetid, fileId, filename, created, submissionid, load_ts
 		) AS z
         WHERE z.RowNum = 1
     )
@@ -137,4 +142,5 @@ SELECT
     *
 FROM
     companyandfiledetails
-
+)
+GO

--- a/src/EPR.CommonDataService.Data/Scripts/Functions/fn_get-uploaded-organisation-details.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Functions/fn_get-uploaded-organisation-details.sql
@@ -9,6 +9,7 @@ GO
 CREATE FUNCTION [dbo].[fn_GetUploadedOrganisationDetails] (@OrganisationUUID [nvarchar](40),@SubmissionPeriod [nvarchar](25)) RETURNS TABLE
 AS
 RETURN (	   
+
 WITH
     LatestUploadedData
     AS
@@ -27,7 +28,7 @@ WITH
 			,FileId
 			,FileName
 			,STRING_AGG(FileType, ',') AS FileTypes
-			,row_number() OVER (partition BY organisationid, submissionid, SubmissionPeriod, ComplianceSchemeId ORDER BY created desc, load_ts DESC) AS RowNum
+			,row_number() OVER (partition BY organisationid, SubmissionPeriod, ComplianceSchemeId ORDER BY created desc, load_ts DESC) AS RowNum
             FROM
                 rpd.cosmos_file_metadata
             WHERE SubmissionType = 'Registration'
@@ -37,7 +38,6 @@ WITH
 		) AS z
         WHERE z.RowNum = 1
     )
---select * from LatestUploadedData
 ,CompanyDetails
     AS
     (
@@ -71,7 +71,6 @@ WITH
                 AND (ISNULL(@SubmissionPeriod,'') = '' OR lud.SubmissionPeriod = @SubmissionPeriod)
         WHERE ISNULL(cd.subsidiary_id,'') = ''
     )
---select * from CompanyDetails
 ,PartnerFileDetails
     AS
     (
@@ -89,7 +88,6 @@ WITH
             INNER JOIN rpd.cosmos_file_metadata cfm ON cfm.registrationsetid = lud.registrationsetid AND UPPER(cfm.FileType) = 'PARTNERSHIPS'
                 AND (ISNULL(@OrganisationUUID,'') = '' OR cfm.organisationid = @OrganisationUUID )
     )
---select * from partnerfiledetails 
 ,BrandFileDetails
     AS
     (
@@ -107,7 +105,6 @@ WITH
             INNER JOIN rpd.cosmos_file_metadata cfm ON cfm.registrationsetid = lud.registrationsetid AND UPPER(cfm.FileType) = 'BRANDS'
                 AND (ISNULL(@OrganisationUUID,'') = '' OR cfm.organisationid = @OrganisationUUID )
     )
---select * from brandfiledetails order by externalid
 ,CompanyAndFileDetails
     AS
     (

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
@@ -367,7 +367,7 @@ DECLARE @IsComplianceScheme bit;
         (
             SELECT
                 CSOReference
-            ,'[' + STRING_AGG(OrganisationDetailsJsonString, ', ') + ']' AS FinalJson
+            ,'[' + STRING_AGG(CONVERT(nvarchar(max),OrganisationDetailsJsonString), ', ') + ']' AS FinalJson
             FROM
                 JsonifiedCompliancePaycalCTE
             WHERE CSOReference = @CSOReferenceNumber

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
@@ -92,6 +92,9 @@ DECLARE @IsComplianceScheme bit;
             AND decisions.SubmissionId = @SubId;
 	');
 
+	IF OBJECT_ID('tempdb..#ProdCommentsRegulatorDecisions') IS NOT NULL
+		DROP TABLE #ProdCommentsRegulatorDecisions;
+
 	EXEC sp_executesql @ProdCommentsSQL, N'@SubId nvarchar(50)', @SubId = @SubmissionId;
 
     WITH
@@ -117,6 +120,11 @@ DECLARE @IsComplianceScheme bit;
 			WHERE IsProducerComment = 0
 					AND SubmissionStatus = 'Granted'
 			ORDER BY DecisionDate DESC
+		)
+		,ProducerSubmissionCTE as (
+			SELECT TOP 1 *
+			from ProdCommentsRegulatorDecisionsCTE producersubmission
+			WHERE IsProducerComment = 1
 		)
 		,UploadedDataCTE as (
 			select *
@@ -182,7 +190,7 @@ DECLARE @IsComplianceScheme bit;
 						END
 					 END AS NationCode
 					,s.SubmissionType
-					,s.UserId AS SubmittedUserId
+					,se.UserId AS SubmittedUserId
 					,CAST(
 						SUBSTRING(
 							s.SubmissionPeriod,
@@ -196,7 +204,7 @@ DECLARE @IsComplianceScheme bit;
 											s.SubmissionPeriod,
 											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
 											4
-										)),4,1) THEN 1
+										)),4,1) THEN 1	-- 1st April cut-off
 							ELSE 0
 						END AS BIT
 					) AS IsLateSubmission
@@ -230,7 +238,7 @@ DECLARE @IsComplianceScheme bit;
 					) AS RowNum
 				FROM
 					[rpd].[Submissions] AS s
-					INNER JOIN ProdCommentsRegulatorDecisionsCTE se on se.SubmissionId = s.SubmissionId and se.IsProducerComment = 1
+					INNER JOIN ProducerSubmissionCTE se on se.SubmissionId = s.SubmissionId
 					INNER JOIN UploadedDataCTE org ON org.SubmittingExternalId = s.OrganisationId
 					INNER JOIN [rpd].[Organisations] o on o.ExternalId = s.OrganisationId
 					LEFT JOIN [rpd].[ComplianceSchemes] cs on cs.ExternalId = s.ComplianceSchemeId 
@@ -310,7 +318,7 @@ DECLARE @IsComplianceScheme bit;
                 SubmissionDetails submission
                 LEFT JOIN LatestRelatedRegulatorDecisionsCTE decision ON decision.SubmissionId = submission.SubmissionId
                 LEFT JOIN LatestProducerCommentEventsCTE producer ON producer.SubmissionId = submission.SubmissionId
-        ) 
+        )
 		,CompliancePaycalCTE
         AS
         (
@@ -328,7 +336,9 @@ DECLARE @IsComplianceScheme bit;
             ,@SubmissionPeriod AS WantedPeriod
             FROM
                 dbo.v_ComplianceSchemeMembers csm
-                INNER JOIN dbo.v_ProducerPayCalParameters ppp ON ppp.OrganisationReference = csm.ReferenceNumber
+                INNER JOIN dbo.v_ProducerPayCalParameters ppp 
+					  ON ppp.OrganisationReference = csm.ReferenceNumber
+					  AND ppp.FileName = csm.FileName
             WHERE @IsComplianceScheme = 1
                 AND csm.CSOReference = @CSOReferenceNumber
                 AND csm.SubmissionPeriod = @SubmissionPeriod

--- a/src/EPR.CommonDataService.Data/Scripts/Views/uploaded-registration-data-by-submission-period.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/uploaded-registration-data-by-submission-period.sql
@@ -7,8 +7,7 @@
 GO
 
 CREATE VIEW [dbo].[v_UploadedRegistrationDataBySubmissionPeriod]
-AS 
-WITH
+AS WITH
     LatestUploadedData
     AS
     (
@@ -30,7 +29,7 @@ WITH
                 rpd.cosmos_file_metadata
             WHERE SubmissionType = 'Registration'
 			AND SubmissionPeriod like 'January to D%'
-            GROUP BY organisationid, submissionperiod, registrationsetid, submissionid, complianceschemeid, created
+            GROUP BY organisationid, submissionperiod, registrationsetid, complianceschemeid, submissionid, created
 		) AS z
         WHERE z.RowNum = 1
     )
@@ -133,5 +132,4 @@ SELECT
     *
 FROM
     companyandfiledetails;
-    
 GO

--- a/src/EPR.CommonDataService.Data/Scripts/Views/uploaded-registration-data-by-submission-period.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/uploaded-registration-data-by-submission-period.sql
@@ -6,8 +6,14 @@
 
 GO
 
-CREATE VIEW [dbo].[v_UploadedRegistrationDataBySubmissionPeriod]
-AS WITH
+/****** Object:  View [dbo].[v_UploadedRegistrationDataBySubmissionPeriod]    Script Date: 31/03/2025 11:27:53 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE VIEW [dbo].[v_UploadedRegistrationDataBySubmissionPeriod] AS WITH
     LatestUploadedData
     AS
     (
@@ -23,13 +29,11 @@ AS WITH
 			,ComplianceSchemeId
 			,CONVERT( BIT, CASE WHEN ComplianceSchemeId IS NULL THEN 0 ELSE 1 END) as IsComplianceUpload
 			,Created
-			,STRING_AGG(FileType, ',') AS FileTypes
 			,row_number() OVER (partition BY organisationid, SubmissionPeriod, ComplianceSchemeId ORDER BY created DESC) AS RowNum
             FROM
                 rpd.cosmos_file_metadata
             WHERE SubmissionType = 'Registration'
 			AND SubmissionPeriod like 'January to D%'
-            GROUP BY organisationid, submissionperiod, registrationsetid, complianceschemeid, submissionid, created
 		) AS z
         WHERE z.RowNum = 1
     )


### PR DESCRIPTION
This PR, for 8.2 comprises SQL changes for the following issues:

- Late Fee being incorrectly calculated 
- Incorrect user showing as submitted person (INC2319921)
- Queried and resubmitted submissions are being lost in regulator view (525452 - https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/525452)
- Cancelled decision date not being returned properly
- STRING_AGG function overflowing - this has been removed from a function and view and amended in Registration FetchDetails SP to convert parameter to nvarchar(max)
- Incorrect join logic in fn Get uploaded organisation details causing issues retrieving data if CompanyDetails is not the first uploaded item
- Confirmation of incorrect join logic for CS member counting is not present

