### PR TITLE
GetOrganisationDetails SQL Function failing to retrieve details consistently

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Functions/fn_get-uploaded-organisation-details.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Functions/fn_get-uploaded-organisation-details.sql
@@ -21,8 +21,6 @@ WITH
 			,RegistrationSetId
 			,ComplianceSchemeId
 			,Created
-			,FileId
-			,FileName
 			,STRING_AGG(FileType, ',') AS FileTypes
 			,row_number() OVER (partition BY organisationid, SubmissionPeriod, ComplianceSchemeId ORDER BY created desc, load_ts DESC) AS RowNum
             FROM
@@ -30,7 +28,7 @@ WITH
             WHERE SubmissionType = 'Registration'
                 AND (ISNULL(@SubmissionPeriod,'') = '' OR SubmissionPeriod = @SubmissionPeriod)
                 AND (ISNULL(@OrganisationUUID,'') = '' OR organisationid = @OrganisationUUID)
-            GROUP BY submissionid, organisationid, submissionperiod, complianceschemeid, registrationsetid, fileId, filename, created, load_ts
+            GROUP BY organisationid, submissionperiod, complianceschemeid, registrationsetid, fileId, filename, created, submissionid, load_ts
 		) AS z
         WHERE z.RowNum = 1
     )
@@ -52,8 +50,6 @@ WITH
 		,cfm.complianceschemeid
 		,CASE WHEN cfm.complianceschemeid IS NOT NULL THEN 1 ELSE 0 END AS IsComplianceScheme
 		,cd.FileName AS CompanyFileName
-		,lud.FileName as LUDFileName
-		,lud.FileId as LUDFileId
 		,cfm.RegistrationSetId AS CompanySetId
 		,cfm.FileId AS CompanyFileId
 		,cfm.Blobname AS CompanyBlobname
@@ -62,9 +58,7 @@ WITH
             LatestUploadedData lud
             INNER JOIN rpd.cosmos_file_metadata cfm ON cfm.registrationsetid = lud.registrationsetid
 			AND UPPER(cfm.FileType) = 'COMPANYDETAILS'
-            INNER JOIN rpd.companydetails cd ON lud.filename = cd.filename
-                AND (ISNULL(@OrganisationUUID,'') = '' OR cfm.organisationid = @OrganisationUUID )
-                AND (ISNULL(@SubmissionPeriod,'') = '' OR lud.SubmissionPeriod = @SubmissionPeriod)
+            INNER JOIN rpd.companydetails cd ON cfm.filename = cd.filename
         WHERE ISNULL(cd.subsidiary_id,'') = ''
     )
 ,PartnerFileDetails
@@ -139,5 +133,3 @@ SELECT
     *
 FROM
     companyandfiledetails
-)
-GO


### PR DESCRIPTION
fn_GetUploadedOrganisationDetails was not behaving properly and consequently some organisations wouldn't load in details view when they should be.
The solution is to make it behave consistently and alike to it's sister view.