### PR TITLE
CSO Calculations are including information for organisations that hav…

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/fetch-organisation-registration-submission-details.sql
@@ -328,7 +328,9 @@ DECLARE @IsComplianceScheme bit;
             ,@SubmissionPeriod AS WantedPeriod
             FROM
                 dbo.v_ComplianceSchemeMembers csm
-                INNER JOIN dbo.v_ProducerPayCalParameters ppp ON ppp.OrganisationReference = csm.ReferenceNumber
+                INNER JOIN dbo.v_ProducerPayCalParameters ppp 
+					ON ppp.OrganisationReference = csm.ReferenceNumber
+					AND ppp.FileName = csm.FileName
             WHERE @IsComplianceScheme = 1
                 AND csm.CSOReference = @CSOReferenceNumber
                 AND csm.SubmissionPeriod = @SubmissionPeriod


### PR DESCRIPTION
The CSO calculation uses a data set that is meant to be restricted to the contents of 1 file.   This is not happening - a join between two sets of data relating to CSO's and their members, and the member details is not complete - the filename was not used to restrict results - so the calculations are including organisations that were previously uploaded and have been changed - leading to total number counts for Paycal to be affected.