### PR TITLE
Bug/544159   late fees rework

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -389,7 +389,8 @@ SET NOCOUNT ON;
 		)
 		,ComplianceSchemeMembersCTE as (
 			select csm.*
-				   ,CASE WHEN csm.SubmittedDate <= ss.RegistrationDecisionDate AND csm.joiner_date is null THEN 1
+				   ,CASE WHEN ss.RegistrationDecisionDate IS NULL THEN 1
+						 WHEN csm.SubmittedDate <= ss.RegistrationDecisionDate AND csm.joiner_date is null THEN 1
 						 ELSE 0 END
 					AS IsOriginal
 				   ,CASE WHEN csm.SubmittedDate<= ss.RegistrationDecisionDate THEN 0
@@ -519,7 +520,7 @@ SET NOCOUNT ON;
         ,r.BrandsBlobName
 		,r.ComplianceSchemeId
 		,r.CSId
-        ,ISNULL(acpp.FinalJson, '{}') AS CSOJson
+        ,acpp.FinalJson AS CSOJson
     FROM
         SubmissionDetails r
         INNER JOIN [rpd].[Organisations] o

--- a/src/EPR.CommonDataService.Data/Scripts/Views/producer-paycal-parameters-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/producer-paycal-parameters-resub.sql
@@ -6,8 +6,8 @@ IF EXISTS (
 
 GO
 
-CREATE VIEW [dbo].[v_ProducerPaycalParameters_resub] AS WITH 
-    OrganisationDetailsCTE AS (
+CREATE VIEW [dbo].[v_ProducerPaycalParameters_resub] AS 
+	WITH OrganisationDetailsCTE AS (
         SELECT 
             cfm.OrganisationId as OrganisationExternalId
 			,cd.Organisation_Id AS OrganisationId
@@ -29,12 +29,16 @@ CREATE VIEW [dbo].[v_ProducerPaycalParameters_resub] AS WITH
                 WHEN 'WS' THEN 4
                 WHEN 'WA' THEN 4
             END AS NationId
+			,cd.leaver_date
+			,cd.leaver_code
+			,cd.organisation_change_reason
+			,cd.joiner_date
         FROM
             [rpd].[CompanyDetails] cd
 			inner join rpd.cosmos_file_metadata cfm on cfm.FileName = cd.FileName
         WHERE cd.Subsidiary_Id IS NULL
     )
-    ,SubsidiaryCountsCTE
+	,SubsidiaryCountsCTE
     AS
     (
         SELECT
@@ -45,7 +49,6 @@ CREATE VIEW [dbo].[v_ProducerPaycalParameters_resub] AS WITH
         FROM
             rpd.companydetails cd
         WHERE cd.Subsidiary_Id IS NOT NULL
-        AND cd.leaver_date IS NULL
         GROUP BY cd.FileName, cd.organisation_id
     )
 	,OrganisationPaycalDetailsCTE AS (


### PR DESCRIPTION
Adjusted logic for Filtering for resubmission of CS members and subsidiaries:
* Ensured the Submitted file ID is used, not just the latest file
* Ensured that a Submission for CS's that is Late has members that are marked as Late (550814)
* Relaxed filtering of CS members on the joiner_date value - including them in the count when the date is empty (the last refinement identified in 544159)