### PR TITLE
Bug/561779 incorrect date for regulator decisions

### DIFF
--- a/src/EPR.CommonDataService.Data/Entities/OrganisationRegistrationDetailsDto.cs
+++ b/src/EPR.CommonDataService.Data/Entities/OrganisationRegistrationDetailsDto.cs
@@ -38,6 +38,7 @@ namespace EPR.CommonDataService.Data.Entities
         public string RegulatorComment { get; set; }
         public string ProducerComment { get; set; }
         public string RegulatorDecisionDate { get; set; }
+        public string RegulatorResubmissionDecisionDate { get; set; }
         public Guid? RegulatorUserId { get; set; }
 
         // organisation details

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -16,12 +16,6 @@ SET NOCOUNT ON;
 	DECLARE @ApplicationReferenceNumber nvarchar(4000);
 	DECLARE @IsComplianceScheme bit;
 
-    DECLARE @LateFeeCutoffDate DATETIME = DATEFROMPARTS(CONVERT( int, SUBSTRING(
-                                        @SubmissionPeriod,
-                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
-                                        4
-                                    )),4, 1); 
-
     SELECT
         @OrganisationIDForSubmission = O.Id 
 		,@OrganisationUUIDForSubmission = O.ExternalId 
@@ -147,12 +141,6 @@ SET NOCOUNT ON;
 			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
 			ORDER BY RowNum asc
 		)
-		,FirstSubmissionCTE AS (
-			SELECT TOP 1 *
-			FROM ReconciledSubmissionEvents
-			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
-			ORDER BY RowNum desc
-		)
 		,InitialDecisionCTE AS (
 			SELECT TOP 1 *
 			FROM ReconciledSubmissionEvents
@@ -192,19 +180,23 @@ SET NOCOUNT ON;
 				 END as SubmissionStatus
 				,s.SubmissionEventId
 				,s.Comment as SubmissionComment
-				,fs.DecisionDate as SubmissionDate
+				,s.DecisionDate as SubmissionDate
 				,CAST(
                     CASE
-                        WHEN fs.DecisionDate > @LateFeeCutoffDate THEN 1
+                        WHEN s.DecisionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
+                                        @SubmissionPeriod,
+                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
+                                        4
+                                    )),4,1) THEN 1
                         ELSE 0
                     END AS BIT
                 ) AS IsLateSubmission
 				,s.FileId as SubmittedFileId
 				,COALESCE(r.UserId, s.UserId) AS SubmittedUserId			
 				
-				,reg.DecisionDate AS RegistrationDecisionDate
+				,COALESCE(reg.DecisionDate, id.DecisionDate) AS RegistrationDecisionDate
 				,id.StatusPendingDate
-				,reg.SubmissionEventId AS RegistrationDecisionEventId
+				,COALESCE(reg.SubmissionEventId, ld.SubmissionEventId, id.SubmissionEventId) AS RegistrationDecisionEventId
 
 				,CASE
 					WHEN r.SubmissionEventId IS NOT NULL AND rd.SubmissionEventId IS NOT NULL THEN rd.ResubmissionStatus
@@ -225,7 +217,6 @@ SET NOCOUNT ON;
 
 				,reg.RegistrationReferenceNumber
 			FROM InitialSubmissionCTE s
-			LEFT JOIN FirstSubmissionCTE fs on fs.SubmissionId = s.SubmissionId
 			LEFT JOIN InitialDecisionCTE id ON id.SubmissionId = s.SubmissionId
 			LEFT JOIN LatestDecisionCTE ld ON ld.SubmissionId = s.SubmissionId
 			LEFT JOIN RegistrationDecisionCTE reg on reg.SubmissionId = s.SubmissionId
@@ -360,7 +351,16 @@ SET NOCOUNT ON;
 							4
 						) AS INT
 					) AS RelevantYear
-					,CAST(ss.IsLateSubmission AS BIT) AS IsLateSubmission
+					,CAST(
+						CASE
+							WHEN SubmittedCTE.SubmissionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
+											s.SubmissionPeriod,
+											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
+											4
+										)),4,1) THEN 1
+							ELSE 0
+						END AS BIT
+					) AS IsLateSubmission
 					,CASE UPPER(TRIM(org.organisationsize))
 						WHEN 'S' THEN 'Small'
 						WHEN 'L' THEN 'Large'

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -201,7 +201,7 @@ BEGIN
                 ) AS IsLateSubmission
 				,s.FileId as SubmittedFileId
 				,COALESCE(r.UserId, s.UserId) AS SubmittedUserId			
-				
+				,COALESCE(ld.DecisionDate, reg.DecisionDate, id.DecisionDate) as RegulatorDecisionDate
 				,reg.DecisionDate AS RegistrationDecisionDate
 				,id.StatusPendingDate
 				,reg.SubmissionEventId AS RegistrationDecisionEventId
@@ -233,7 +233,7 @@ BEGIN
 			LEFT JOIN ResubmissionDecisionCTE rd ON rd.SubmissionId = r.SubmissionId AND rd.FileId = r.FileId
 			order by resubmissiondecisiondate desc
 		)
-		,SubmittedCTE as (
+	,SubmittedCTE as (
 			SELECT SubmissionId, 
 					SubmissionEventId, 
 					SubmissionComment, 
@@ -356,7 +356,8 @@ BEGIN
 					 END AS NationCode
 					,ss.RegulatorUserId
 					,ss.ResubmissionEventId
-					,GREATEST(ss.RegistrationDecisionDate,ss.ResubmissionDecisionDate) as RegulatorDecisionDate
+					,GREATEST(ss.RegistrationDecisionDate, ss.RegulatorDecisionDate) as RegulatorDecisionDate
+					,ss.ResubmissionDecisionDate as RegulatorResubmissionDecisionDate
 					,CASE WHEN ss.SubmissionStatus = 'Cancelled' 
 						  THEN ss.StatusPendingDate
 						  ELSE null
@@ -518,6 +519,7 @@ BEGIN
         ,r.RegulatorComment
         ,r.ProducerComment
         ,r.RegulatorDecisionDate
+		,r.RegulatorResubmissionDecisionDate
         ,r.RegulatorUserId
         ,o.CompaniesHouseNumber
         ,o.BuildingName

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -16,6 +16,12 @@ SET NOCOUNT ON;
 	DECLARE @ApplicationReferenceNumber nvarchar(4000);
 	DECLARE @IsComplianceScheme bit;
 
+    DECLARE @LateFeeCutoffDate DATETIME = DATEFROMPARTS(CONVERT( int, SUBSTRING(
+                                        @SubmissionPeriod,
+                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
+                                        4
+                                    )),4, 1); 
+
     SELECT
         @OrganisationIDForSubmission = O.Id 
 		,@OrganisationUUIDForSubmission = O.ExternalId 
@@ -141,6 +147,12 @@ SET NOCOUNT ON;
 			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
 			ORDER BY RowNum asc
 		)
+		,FirstSubmissionCTE AS (
+			SELECT TOP 1 *
+			FROM ReconciledSubmissionEvents
+			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
+			ORDER BY RowNum desc
+		)
 		,InitialDecisionCTE AS (
 			SELECT TOP 1 *
 			FROM ReconciledSubmissionEvents
@@ -180,23 +192,19 @@ SET NOCOUNT ON;
 				 END as SubmissionStatus
 				,s.SubmissionEventId
 				,s.Comment as SubmissionComment
-				,s.DecisionDate as SubmissionDate
+				,fs.DecisionDate as SubmissionDate
 				,CAST(
                     CASE
-                        WHEN s.DecisionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
-                                        @SubmissionPeriod,
-                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
-                                        4
-                                    )),4,1) THEN 1
+                        WHEN fs.DecisionDate > @LateFeeCutoffDate THEN 1
                         ELSE 0
                     END AS BIT
                 ) AS IsLateSubmission
 				,s.FileId as SubmittedFileId
 				,COALESCE(r.UserId, s.UserId) AS SubmittedUserId			
 				
-				,COALESCE(reg.DecisionDate, id.DecisionDate) AS RegistrationDecisionDate
+				,reg.DecisionDate AS RegistrationDecisionDate
 				,id.StatusPendingDate
-				,COALESCE(reg.SubmissionEventId, ld.SubmissionEventId, id.SubmissionEventId) AS RegistrationDecisionEventId
+				,reg.SubmissionEventId AS RegistrationDecisionEventId
 
 				,CASE
 					WHEN r.SubmissionEventId IS NOT NULL AND rd.SubmissionEventId IS NOT NULL THEN rd.ResubmissionStatus
@@ -217,6 +225,7 @@ SET NOCOUNT ON;
 
 				,reg.RegistrationReferenceNumber
 			FROM InitialSubmissionCTE s
+			LEFT JOIN FirstSubmissionCTE fs on fs.SubmissionId = s.SubmissionId
 			LEFT JOIN InitialDecisionCTE id ON id.SubmissionId = s.SubmissionId
 			LEFT JOIN LatestDecisionCTE ld ON ld.SubmissionId = s.SubmissionId
 			LEFT JOIN RegistrationDecisionCTE reg on reg.SubmissionId = s.SubmissionId
@@ -351,16 +360,7 @@ SET NOCOUNT ON;
 							4
 						) AS INT
 					) AS RelevantYear
-					,CAST(
-						CASE
-							WHEN SubmittedCTE.SubmissionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
-											s.SubmissionPeriod,
-											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
-											4
-										)),4,1) THEN 1
-							ELSE 0
-						END AS BIT
-					) AS IsLateSubmission
+					,CAST(ss.IsLateSubmission AS BIT) AS IsLateSubmission
 					,CASE UPPER(TRIM(org.organisationsize))
 						WHEN 'S' THEN 'Small'
 						WHEN 'L' THEN 'Large'


### PR DESCRIPTION
This change brings back 1 date and introduces a new date to the output of OrganisationRegistrationSubmissionDetails:
1:  RegulatorDecisionDate went missing during a recent refactor for LateFees
2:  RegulatorResubmissionDecisionDate has been added to the output

This clears-up date-rendering issues on the UI.