### PR TITLE
Bug/586407 test 1hr command timeout

### DIFF
--- a/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
+++ b/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using EPR.CommonDataService.Api.Configuration;
 using EPR.CommonDataService.Core.Services;
+using EPR.CommonDataService.Data;
 using EPR.CommonDataService.Data.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json.Serialization;
@@ -21,7 +22,7 @@ public static class ServiceProviderExtensions
 
     public static IServiceCollection RegisterDataComponents(this IServiceCollection services, IConfiguration configuration)
     {
-        int timeoutInSeconds = configuration.GetValue<int?>("CommandTimeoutSeconds") ?? 4000;
+        int timeoutInSeconds = configuration.GetValue<int?>("CommandTimeoutSeconds") ?? ManifestConstants.NOMINAL_MAX_CMD_TIMEOUT;
 
         services.AddDbContext<SynapseContext>(options => options.UseSqlServer(configuration.GetConnectionString("SynapseDatabase"),
                                                          sqloptions => sqloptions.CommandTimeout(timeoutInSeconds)));

--- a/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
+++ b/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
@@ -21,7 +21,10 @@ public static class ServiceProviderExtensions
 
     public static IServiceCollection RegisterDataComponents(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddDbContext<SynapseContext>(options => options.UseSqlServer(configuration.GetConnectionString("SynapseDatabase")));
+        int timeoutInSeconds = configuration.GetValue<int?>("CommandTimeoutSeconds") ?? 4000;
+
+        services.AddDbContext<SynapseContext>(options => options.UseSqlServer(configuration.GetConnectionString("SynapseDatabase"),
+                                                         sqloptions => sqloptions.CommandTimeout(timeoutInSeconds)));
         return services;
     }
 

--- a/src/EPR.CommonDataService.Api/appsettings.json
+++ b/src/EPR.CommonDataService.Api/appsettings.json
@@ -12,6 +12,7 @@
         }
     },
     "AllowedHosts": "*",
+    "CommandTimeoutSeconds": 3600,
     "HealthCheckPath": "/admin/health",
     "LogPrefix": "[EPR.CommonDataService]",
     "ApiConfig": {

--- a/src/EPR.CommonDataService.Core/Services/SubmissionsService.cs
+++ b/src/EPR.CommonDataService.Core/Services/SubmissionsService.cs
@@ -91,7 +91,6 @@ public class SubmissionsService(SynapseContext accountsDbContext, IDatabaseTimeo
 
         try
         {
-            ///databaseTimeoutService.SetCommandTimeout(accountsDbContext, 120);
             var dataset = await accountsDbContext.RunSqlAsync<OrganisationRegistrationSummaryDataRow>(sql, sqlParameters);
             var itemsCount = dataset.FirstOrDefault()?.TotalItems ?? 0;
 

--- a/src/EPR.CommonDataService.Core/Services/SubmissionsService.cs
+++ b/src/EPR.CommonDataService.Core/Services/SubmissionsService.cs
@@ -112,12 +112,11 @@ public class SubmissionsService(SynapseContext accountsDbContext, IDatabaseTimeo
     public async Task<OrganisationRegistrationDetailsDto?> GetOrganisationRegistrationSubmissionDetails(OrganisationRegistrationDetailRequest request)
     {
         logger.LogInformation("{Logprefix}: SubmissionsService - GetOrganisationRegistrationSubmissionDetails: Get OrganisationRegistrationSubmissionDetails for given request {Request}", _logPrefix, JsonConvert.SerializeObject(request));
-        var sql = "dbo.sp_FetchOrganisationRegistrationSubmissionDetails_resub";
+        var sql = "dbo.sp_FetchOrganisationRegistrationSubmissionDetails_resub_withdelay";
         var sqlParameters = request.ToProcParams();
 
         try
         {
-            //databaseTimeoutService.SetCommandTimeout(accountsDbContext, 120);
             var dbSet = await accountsDbContext.RunSpCommandAsync<OrganisationRegistrationDetailsDto>(sql, logger, _logPrefix, sqlParameters);
 
             return dbSet.FirstOrDefault();

--- a/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
+++ b/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
@@ -235,7 +235,7 @@ public class SynapseContext : DbContext
 
     public virtual async Task<IList<TEntity>> RunSqlAsync<TEntity>(string sql, params object[] parameters) where TEntity : class
     {
-        int timeout = Database.GetCommandTimeout() ?? 4000;
+        int timeout = Database.GetCommandTimeout() ?? ManifestConstants.NOMINAL_MAX_CMD_TIMEOUT;
         Database.SetCommandTimeout(timeout);
         return await Set<TEntity>().FromSqlRaw(sql, parameters).AsAsyncEnumerable().ToListAsync();
     }
@@ -379,7 +379,7 @@ public class SynapseContext : DbContext
     private static DbCommand CreateCommand(DatabaseFacade database, DbConnection connection, string sql, SqlParameter[] parameters)
     {
         var command = connection.CreateCommand();
-        command.CommandTimeout = database.GetCommandTimeout() ?? 3600;
+        command.CommandTimeout = database.GetCommandTimeout() ?? ManifestConstants.NOMINAL_MAX_CMD_TIMEOUT;
 
         command.CommandText = sql;
         command.CommandType = CommandType.StoredProcedure;

--- a/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
+++ b/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
@@ -2,6 +2,7 @@ using EPR.CommonDataService.Data.Converters;
 using EPR.CommonDataService.Data.Entities;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 using System.Collections.ObjectModel;
 using System.Data;
@@ -234,6 +235,8 @@ public class SynapseContext : DbContext
 
     public virtual async Task<IList<TEntity>> RunSqlAsync<TEntity>(string sql, params object[] parameters) where TEntity : class
     {
+        int timeout = Database.GetCommandTimeout() ?? 4000;
+        Database.SetCommandTimeout(timeout);
         return await Set<TEntity>().FromSqlRaw(sql, parameters).AsAsyncEnumerable().ToListAsync();
     }
 
@@ -248,9 +251,8 @@ public class SynapseContext : DbContext
 
             if (connection.State == ConnectionState.Open)
             {
-                var command = CreateCommand(connection, storedProcName, parameters);
-                command.CommandTimeout = Database.GetCommandTimeout() ?? 120;
-
+                var command = CreateCommand(Database, connection, storedProcName, parameters);
+                
                 var readerResult = await command.ExecuteReaderAsync();
                 var result = await PopulateDto<TEntity>(readerResult, logger, logPrefix);
 
@@ -373,9 +375,26 @@ public class SynapseContext : DbContext
         (dataType == typeof(string) || dataType == typeof(DateTime)) &&
         (propType == typeof(DateTime) || propType == typeof(DateTime?));
 
+
+    private static DbCommand CreateCommand(DatabaseFacade database, DbConnection connection, string sql, SqlParameter[] parameters)
+    {
+        var command = connection.CreateCommand();
+        command.CommandTimeout = database.GetCommandTimeout() ?? 3600;
+
+        command.CommandText = sql;
+        command.CommandType = CommandType.StoredProcedure;
+        foreach (var parameter in parameters)
+        {
+            command.Parameters.Add(parameter);
+        }
+
+        return command;
+    }
+
     private static DbCommand CreateCommand(DbConnection connection, string sql, params SqlParameter[] parameters)
     {
         var command = connection.CreateCommand();
+        
         command.CommandText = sql;
         command.CommandType = CommandType.StoredProcedure;
         foreach (var parameter in parameters)

--- a/src/EPR.CommonDataService.Data/ManifestConstants.cs
+++ b/src/EPR.CommonDataService.Data/ManifestConstants.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EPR.CommonDataService.Data
+{
+    public static class ManifestConstants
+    {
+        public const int NOMINAL_MAX_CMD_TIMEOUT = 4000;
+
+    }
+}

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -16,12 +16,6 @@ SET NOCOUNT ON;
 	DECLARE @ApplicationReferenceNumber nvarchar(4000);
 	DECLARE @IsComplianceScheme bit;
 
-    DECLARE @LateFeeCutoffDate DATETIME = DATEFROMPARTS(CONVERT( int, SUBSTRING(
-                                        @SubmissionPeriod,
-                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
-                                        4
-                                    )),4, 1); 
-
     SELECT
         @OrganisationIDForSubmission = O.Id 
 		,@OrganisationUUIDForSubmission = O.ExternalId 
@@ -147,12 +141,6 @@ SET NOCOUNT ON;
 			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
 			ORDER BY RowNum asc
 		)
-		,FirstSubmissionCTE AS (
-			SELECT TOP 1 *
-			FROM ReconciledSubmissionEvents
-			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
-			ORDER BY RowNum desc
-		)
 		,InitialDecisionCTE AS (
 			SELECT TOP 1 *
 			FROM ReconciledSubmissionEvents
@@ -192,19 +180,23 @@ SET NOCOUNT ON;
 				 END as SubmissionStatus
 				,s.SubmissionEventId
 				,s.Comment as SubmissionComment
-				,fs.DecisionDate as SubmissionDate
+				,s.DecisionDate as SubmissionDate
 				,CAST(
                     CASE
-                        WHEN fs.DecisionDate > @LateFeeCutoffDate THEN 1
+                        WHEN s.DecisionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
+                                        @SubmissionPeriod,
+                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
+                                        4
+                                    )),4,1) THEN 1
                         ELSE 0
                     END AS BIT
                 ) AS IsLateSubmission
 				,s.FileId as SubmittedFileId
 				,COALESCE(r.UserId, s.UserId) AS SubmittedUserId			
 				
-				,reg.DecisionDate AS RegistrationDecisionDate
+				,COALESCE(reg.DecisionDate, id.DecisionDate) AS RegistrationDecisionDate
 				,id.StatusPendingDate
-				,reg.SubmissionEventId AS RegistrationDecisionEventId
+				,COALESCE(reg.SubmissionEventId, ld.SubmissionEventId, id.SubmissionEventId) AS RegistrationDecisionEventId
 
 				,CASE
 					WHEN r.SubmissionEventId IS NOT NULL AND rd.SubmissionEventId IS NOT NULL THEN rd.ResubmissionStatus
@@ -225,7 +217,6 @@ SET NOCOUNT ON;
 
 				,reg.RegistrationReferenceNumber
 			FROM InitialSubmissionCTE s
-			LEFT JOIN FirstSubmissionCTE fs on fs.SubmissionId = s.SubmissionId
 			LEFT JOIN InitialDecisionCTE id ON id.SubmissionId = s.SubmissionId
 			LEFT JOIN LatestDecisionCTE ld ON ld.SubmissionId = s.SubmissionId
 			LEFT JOIN RegistrationDecisionCTE reg on reg.SubmissionId = s.SubmissionId
@@ -360,7 +351,16 @@ SET NOCOUNT ON;
 							4
 						) AS INT
 					) AS RelevantYear
-					,CAST(ss.IsLateSubmission AS BIT) AS IsLateSubmission
+					,CAST(
+						CASE
+							WHEN SubmittedCTE.SubmissionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
+											s.SubmissionPeriod,
+											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
+											4
+										)),4,1) THEN 1
+							ELSE 0
+						END AS BIT
+					) AS IsLateSubmission
 					,CASE UPPER(TRIM(org.organisationsize))
 						WHEN 'S' THEN 'Small'
 						WHEN 'L' THEN 'Large'

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -16,6 +16,12 @@ SET NOCOUNT ON;
 	DECLARE @ApplicationReferenceNumber nvarchar(4000);
 	DECLARE @IsComplianceScheme bit;
 
+    DECLARE @LateFeeCutoffDate DATETIME = DATEFROMPARTS(CONVERT( int, SUBSTRING(
+                                        @SubmissionPeriod,
+                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
+                                        4
+                                    )),4, 1); 
+
     SELECT
         @OrganisationIDForSubmission = O.Id 
 		,@OrganisationUUIDForSubmission = O.ExternalId 
@@ -141,6 +147,12 @@ SET NOCOUNT ON;
 			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
 			ORDER BY RowNum asc
 		)
+		,FirstSubmissionCTE AS (
+			SELECT TOP 1 *
+			FROM ReconciledSubmissionEvents
+			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
+			ORDER BY RowNum desc
+		)
 		,InitialDecisionCTE AS (
 			SELECT TOP 1 *
 			FROM ReconciledSubmissionEvents
@@ -180,23 +192,19 @@ SET NOCOUNT ON;
 				 END as SubmissionStatus
 				,s.SubmissionEventId
 				,s.Comment as SubmissionComment
-				,s.DecisionDate as SubmissionDate
+				,fs.DecisionDate as SubmissionDate
 				,CAST(
                     CASE
-                        WHEN s.DecisionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
-                                        @SubmissionPeriod,
-                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
-                                        4
-                                    )),4,1) THEN 1
+                        WHEN fs.DecisionDate > @LateFeeCutoffDate THEN 1
                         ELSE 0
                     END AS BIT
                 ) AS IsLateSubmission
 				,s.FileId as SubmittedFileId
 				,COALESCE(r.UserId, s.UserId) AS SubmittedUserId			
 				
-				,COALESCE(reg.DecisionDate, id.DecisionDate) AS RegistrationDecisionDate
+				,reg.DecisionDate AS RegistrationDecisionDate
 				,id.StatusPendingDate
-				,COALESCE(reg.SubmissionEventId, ld.SubmissionEventId, id.SubmissionEventId) AS RegistrationDecisionEventId
+				,reg.SubmissionEventId AS RegistrationDecisionEventId
 
 				,CASE
 					WHEN r.SubmissionEventId IS NOT NULL AND rd.SubmissionEventId IS NOT NULL THEN rd.ResubmissionStatus
@@ -217,6 +225,7 @@ SET NOCOUNT ON;
 
 				,reg.RegistrationReferenceNumber
 			FROM InitialSubmissionCTE s
+			LEFT JOIN FirstSubmissionCTE fs on fs.SubmissionId = s.SubmissionId
 			LEFT JOIN InitialDecisionCTE id ON id.SubmissionId = s.SubmissionId
 			LEFT JOIN LatestDecisionCTE ld ON ld.SubmissionId = s.SubmissionId
 			LEFT JOIN RegistrationDecisionCTE reg on reg.SubmissionId = s.SubmissionId
@@ -351,16 +360,7 @@ SET NOCOUNT ON;
 							4
 						) AS INT
 					) AS RelevantYear
-					,CAST(
-						CASE
-							WHEN SubmittedCTE.SubmissionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
-											s.SubmissionPeriod,
-											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
-											4
-										)),4,1) THEN 1
-							ELSE 0
-						END AS BIT
-					) AS IsLateSubmission
+					,CAST(ss.IsLateSubmission AS BIT) AS IsLateSubmission
 					,CASE UPPER(TRIM(org.organisationsize))
 						WHEN 'S' THEN 'Small'
 						WHEN 'L' THEN 'Large'


### PR DESCRIPTION
Added explicit command-timeout value to app settings.
Applied this value (or a default of 4000, if not provided) to the Database at service creation, and to the Database and Commands during common execution paths and specific Stored-Proc execution paths.
It has been tested locally with 4 seconds, 3600 seconds and without any value in the settings.

The Settings file will be deployed with the app, and can be overridden with the Environment variable CommandTimeoutSeconds