### PR TITLE
Bug/568047 Apply command timeouts on RC10

### DIFF
--- a/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
+++ b/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using EPR.CommonDataService.Api.Configuration;
 using EPR.CommonDataService.Core.Services;
+using EPR.CommonDataService.Data;
 using EPR.CommonDataService.Data.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json.Serialization;
@@ -21,7 +22,11 @@ public static class ServiceProviderExtensions
 
     public static IServiceCollection RegisterDataComponents(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddDbContext<SynapseContext>(options => options.UseSqlServer(configuration.GetConnectionString("SynapseDatabase")));
+        int timeoutInSeconds = configuration.GetValue<int?>("CommandTimeoutSeconds") ?? ManifestConstants.NOMINAL_MAX_CMD_TIMEOUT;
+
+        services.AddDbContext<SynapseContext>(options => options.UseSqlServer(configuration.GetConnectionString("SynapseDatabase"),
+                                                         sqloptions => sqloptions.CommandTimeout(timeoutInSeconds)));
+        
         return services;
     }
 

--- a/src/EPR.CommonDataService.Api/appsettings.json
+++ b/src/EPR.CommonDataService.Api/appsettings.json
@@ -1,24 +1,25 @@
 {
-    "Logging": {
-        "ApplicationInsights": {
-            "LogLevel": {
-                "Default": "Information",
-                "Microsoft": "Warning"
-            }
-        },
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
+  "Logging": {
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft": "Warning"
+      }
     },
-    "AllowedHosts": "*",
-    "HealthCheckPath": "/admin/health",
-    "LogPrefix": "[EPR.CommonDataService]",
-    "ApiConfig": {
-      "BaseProblemTypePath": "https://epr-errors/",
-      "PomDataSubmissionPeriods": "2024-P1,2024-P4",
-      "IncludePackagingTypes": "HH,NH,PB,HDC,NHC",
-      "IncludePackagingMaterials": "AL,FC,GL,PC,PL,ST,WD",
-      "IncludeOrganisationSize": "L"
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "CommandTimeoutSeconds": 3600,
+  "HealthCheckPath": "/admin/health",
+  "LogPrefix": "[EPR.CommonDataService]",
+  "ApiConfig": {
+    "BaseProblemTypePath": "https://epr-errors/",
+    "PomDataSubmissionPeriods": "2024-P1,2024-P4",
+    "IncludePackagingTypes": "HH,NH,PB,HDC,NHC",
+    "IncludePackagingMaterials": "AL,FC,GL,PC,PL,ST,WD",
+    "IncludeOrganisationSize": "L"
   }
 }

--- a/src/EPR.CommonDataService.Core/Services/SubmissionsService.cs
+++ b/src/EPR.CommonDataService.Core/Services/SubmissionsService.cs
@@ -117,7 +117,6 @@ public class SubmissionsService(SynapseContext accountsDbContext, IDatabaseTimeo
 
         try
         {
-            //databaseTimeoutService.SetCommandTimeout(accountsDbContext, 120);
             var dbSet = await accountsDbContext.RunSpCommandAsync<OrganisationRegistrationDetailsDto>(sql, logger, _logPrefix, sqlParameters);
 
             return dbSet.FirstOrDefault();

--- a/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
+++ b/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
@@ -2,6 +2,7 @@ using EPR.CommonDataService.Data.Converters;
 using EPR.CommonDataService.Data.Entities;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 using System.Collections.ObjectModel;
 using System.Data;
@@ -234,6 +235,8 @@ public class SynapseContext : DbContext
 
     public virtual async Task<IList<TEntity>> RunSqlAsync<TEntity>(string sql, params object[] parameters) where TEntity : class
     {
+        int timeout = Database.GetCommandTimeout() ?? ManifestConstants.NOMINAL_MAX_CMD_TIMEOUT;
+        Database.SetCommandTimeout(timeout);
         return await Set<TEntity>().FromSqlRaw(sql, parameters).AsAsyncEnumerable().ToListAsync();
     }
 
@@ -248,9 +251,8 @@ public class SynapseContext : DbContext
 
             if (connection.State == ConnectionState.Open)
             {
-                var command = CreateCommand(connection, storedProcName, parameters);
-                command.CommandTimeout = Database.GetCommandTimeout() ?? 120;
-
+                var command = CreateCommand(Database, connection, storedProcName, parameters);
+                
                 var readerResult = await command.ExecuteReaderAsync();
                 var result = await PopulateDto<TEntity>(readerResult, logger, logPrefix);
 
@@ -373,9 +375,11 @@ public class SynapseContext : DbContext
         (dataType == typeof(string) || dataType == typeof(DateTime)) &&
         (propType == typeof(DateTime) || propType == typeof(DateTime?));
 
-    private static DbCommand CreateCommand(DbConnection connection, string sql, params SqlParameter[] parameters)
+    private static DbCommand CreateCommand(DatabaseFacade database, DbConnection connection, string sql, params SqlParameter[] parameters)
     {
         var command = connection.CreateCommand();
+        command.CommandTimeout = database.GetCommandTimeout() ?? ManifestConstants.NOMINAL_MAX_CMD_TIMEOUT;
+
         command.CommandText = sql;
         command.CommandType = CommandType.StoredProcedure;
         foreach (var parameter in parameters)

--- a/src/EPR.CommonDataService.Data/ManifestConstants.cs
+++ b/src/EPR.CommonDataService.Data/ManifestConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace EPR.CommonDataService.Data
+{
+    public static class ManifestConstants
+    {
+        public const int NOMINAL_MAX_CMD_TIMEOUT = 4000;
+
+    }
+}

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -16,12 +16,6 @@ SET NOCOUNT ON;
 	DECLARE @ApplicationReferenceNumber nvarchar(4000);
 	DECLARE @IsComplianceScheme bit;
 
-    DECLARE @LateFeeCutoffDate DATETIME = DATEFROMPARTS(CONVERT( int, SUBSTRING(
-                                        @SubmissionPeriod,
-                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
-                                        4
-                                    )),4, 1); 
-
     SELECT
         @OrganisationIDForSubmission = O.Id 
 		,@OrganisationUUIDForSubmission = O.ExternalId 
@@ -147,12 +141,6 @@ SET NOCOUNT ON;
 			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
 			ORDER BY RowNum asc
 		)
-		,FirstSubmissionCTE AS (
-			SELECT TOP 1 *
-			FROM ReconciledSubmissionEvents
-			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
-			ORDER BY RowNum desc
-		)
 		,InitialDecisionCTE AS (
 			SELECT TOP 1 *
 			FROM ReconciledSubmissionEvents
@@ -192,19 +180,23 @@ SET NOCOUNT ON;
 				 END as SubmissionStatus
 				,s.SubmissionEventId
 				,s.Comment as SubmissionComment
-				,fs.DecisionDate as SubmissionDate
+				,s.DecisionDate as SubmissionDate
 				,CAST(
                     CASE
-                        WHEN fs.DecisionDate > @LateFeeCutoffDate THEN 1
+                        WHEN s.DecisionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
+                                        @SubmissionPeriod,
+                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
+                                        4
+                                    )),4,1) THEN 1
                         ELSE 0
                     END AS BIT
                 ) AS IsLateSubmission
 				,s.FileId as SubmittedFileId
 				,COALESCE(r.UserId, s.UserId) AS SubmittedUserId			
 				
-				,reg.DecisionDate AS RegistrationDecisionDate
+				,COALESCE(reg.DecisionDate, id.DecisionDate) AS RegistrationDecisionDate
 				,id.StatusPendingDate
-				,reg.SubmissionEventId AS RegistrationDecisionEventId
+				,COALESCE(reg.SubmissionEventId, ld.SubmissionEventId, id.SubmissionEventId) AS RegistrationDecisionEventId
 
 				,CASE
 					WHEN r.SubmissionEventId IS NOT NULL AND rd.SubmissionEventId IS NOT NULL THEN rd.ResubmissionStatus
@@ -225,7 +217,6 @@ SET NOCOUNT ON;
 
 				,reg.RegistrationReferenceNumber
 			FROM InitialSubmissionCTE s
-			LEFT JOIN FirstSubmissionCTE fs on fs.SubmissionId = s.SubmissionId
 			LEFT JOIN InitialDecisionCTE id ON id.SubmissionId = s.SubmissionId
 			LEFT JOIN LatestDecisionCTE ld ON ld.SubmissionId = s.SubmissionId
 			LEFT JOIN RegistrationDecisionCTE reg on reg.SubmissionId = s.SubmissionId
@@ -360,7 +351,16 @@ SET NOCOUNT ON;
 							4
 						) AS INT
 					) AS RelevantYear
-					,CAST(ss.IsLateSubmission AS BIT) AS IsLateSubmission
+					,CAST(
+						CASE
+							WHEN SubmittedCTE.SubmissionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
+											s.SubmissionPeriod,
+											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
+											4
+										)),4,1) THEN 1
+							ELSE 0
+						END AS BIT
+					) AS IsLateSubmission
 					,CASE UPPER(TRIM(org.organisationsize))
 						WHEN 'S' THEN 'Small'
 						WHEN 'L' THEN 'Large'

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -16,6 +16,12 @@ SET NOCOUNT ON;
 	DECLARE @ApplicationReferenceNumber nvarchar(4000);
 	DECLARE @IsComplianceScheme bit;
 
+    DECLARE @LateFeeCutoffDate DATETIME = DATEFROMPARTS(CONVERT( int, SUBSTRING(
+                                        @SubmissionPeriod,
+                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
+                                        4
+                                    )),4, 1); 
+
     SELECT
         @OrganisationIDForSubmission = O.Id 
 		,@OrganisationUUIDForSubmission = O.ExternalId 
@@ -141,6 +147,12 @@ SET NOCOUNT ON;
 			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
 			ORDER BY RowNum asc
 		)
+		,FirstSubmissionCTE AS (
+			SELECT TOP 1 *
+			FROM ReconciledSubmissionEvents
+			WHERE IsProducerSubmission = 1 AND IsProducerResubmission = 0
+			ORDER BY RowNum desc
+		)
 		,InitialDecisionCTE AS (
 			SELECT TOP 1 *
 			FROM ReconciledSubmissionEvents
@@ -180,23 +192,19 @@ SET NOCOUNT ON;
 				 END as SubmissionStatus
 				,s.SubmissionEventId
 				,s.Comment as SubmissionComment
-				,s.DecisionDate as SubmissionDate
+				,fs.DecisionDate as SubmissionDate
 				,CAST(
                     CASE
-                        WHEN s.DecisionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
-                                        @SubmissionPeriod,
-                                        PATINDEX('%[0-9][0-9][0-9][0-9]', @SubmissionPeriod),
-                                        4
-                                    )),4,1) THEN 1
+                        WHEN fs.DecisionDate > @LateFeeCutoffDate THEN 1
                         ELSE 0
                     END AS BIT
                 ) AS IsLateSubmission
 				,s.FileId as SubmittedFileId
 				,COALESCE(r.UserId, s.UserId) AS SubmittedUserId			
 				
-				,COALESCE(reg.DecisionDate, id.DecisionDate) AS RegistrationDecisionDate
+				,reg.DecisionDate AS RegistrationDecisionDate
 				,id.StatusPendingDate
-				,COALESCE(reg.SubmissionEventId, ld.SubmissionEventId, id.SubmissionEventId) AS RegistrationDecisionEventId
+				,reg.SubmissionEventId AS RegistrationDecisionEventId
 
 				,CASE
 					WHEN r.SubmissionEventId IS NOT NULL AND rd.SubmissionEventId IS NOT NULL THEN rd.ResubmissionStatus
@@ -217,6 +225,7 @@ SET NOCOUNT ON;
 
 				,reg.RegistrationReferenceNumber
 			FROM InitialSubmissionCTE s
+			LEFT JOIN FirstSubmissionCTE fs on fs.SubmissionId = s.SubmissionId
 			LEFT JOIN InitialDecisionCTE id ON id.SubmissionId = s.SubmissionId
 			LEFT JOIN LatestDecisionCTE ld ON ld.SubmissionId = s.SubmissionId
 			LEFT JOIN RegistrationDecisionCTE reg on reg.SubmissionId = s.SubmissionId
@@ -351,16 +360,7 @@ SET NOCOUNT ON;
 							4
 						) AS INT
 					) AS RelevantYear
-					,CAST(
-						CASE
-							WHEN SubmittedCTE.SubmissionDate > DATEFROMPARTS(CONVERT( int, SUBSTRING(
-											s.SubmissionPeriod,
-											PATINDEX('%[0-9][0-9][0-9][0-9]', s.SubmissionPeriod),
-											4
-										)),4,1) THEN 1
-							ELSE 0
-						END AS BIT
-					) AS IsLateSubmission
+					,CAST(ss.IsLateSubmission AS BIT) AS IsLateSubmission
 					,CASE UPPER(TRIM(org.organisationsize))
 						WHEN 'S' THEN 'Small'
 						WHEN 'L' THEN 'Large'


### PR DESCRIPTION
Change to ensure CommandTimeout is applied to SQL Commands.

There is a new AppSetting - set to 3600, called _CommandTimeoutSeconds_.

This is applied at Database Service construction
And subsequently applied to all commands in the DB context.
