### PR TITLE
575749 - Small Producer CS Member Late Fee Cutoff Date issue

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -476,9 +476,13 @@ BEGIN
 				,ppp.ProducerSize
 				,csm.SubmittedDate
 				,CASE WHEN csm.IsNewJoiner = 1 THEN csm.IsLateFeeApplicable
-					  WHEN csm.IsOriginal = 1 THEN csm.IsLateFeeApplicable
-					  ELSE csm.IsLateSubmission END 
-			     AS IsLateFeeApplicable
+  					  ELSE CASE WHEN csm.organisation_size = 'S' THEN
+									CASE WHEN csm.SubmittedOn > @SmallLateFeeCutoffDate THEN 1 ELSE 0 END
+								WHEN csm.organisation_size = 'L' THEN
+									CASE WHEN csm.SubmittedOn > @CSLLateFeeCutoffDate THEN 1 ELSE 0 END
+								ELSE csm.IsLateSubmission 
+						   END
+				 END AS IsLateFeeApplicable
 				,csm.OrganisationName
 				,csm.leaver_code
 				,csm.leaver_date


### PR DESCRIPTION
Applied the correct cutoff date for the main submission earliestsubmissiondate when that date is used as fallback for a CS member's Late Fee applicability....

Previously, it was using the IsLateSubmission value from the SubmissionStatus, which for a compliance scheme, uses the wrong cutoff date which creates a problem for a small producer when it's a member of a compliance scheme