### PR TITLE
[601604] Adjust Subsidiary counts to align with new rules -

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -254,11 +254,6 @@ BEGIN
 					ResubmissionDate
 			FROM SubmissionStatusCTE
 		)
-		,AppropriateSubmissionDateCTE as (
-			SELECT S.SubmissionDate, P.ResubmissionDate 
-			FROM SubmittedCTE S LEFT JOIN ResubmissionDetailsCTE P
-			ON P.SubmissionId = S.SubmissionId
-		)
 		,UploadedDataForOrganisationCTE as (
 			select distinct org.*
 			FROM
@@ -289,7 +284,6 @@ BEGIN
 				,org.PartnerBlobName
 			FROM
 				UploadedDataForOrganisationCTE org 
-				WHERE org.UploadDate <= (SELECT ISNULL(ResubmissionDate, SubmissionDate) FROM AppropriateSubmissionDateCTE)			
 		)
 		,ProducerPaycalParametersCTE
 			AS
@@ -305,7 +299,7 @@ BEGIN
 				,NumberOfSubsidiaries
 				,OnlineMarketPlaceSubsidiaries
 				FROM
-					[dbo].[v_ProducerPaycalParameters_resub] AS ppp
+					[dbo].[t_ProducerPaycalParameters_resub] AS ppp
 				WHERE ppp.FileId in (SELECT FileId from SubmissionStatusCTE)
 		)
 		,SubmissionDetails AS (
@@ -470,7 +464,7 @@ BEGIN
 				ComplianceSchemeMembersCTE csm
 				INNER JOIN dbo.t_ProducerPayCalParameters_resub ppp ON ppp.OrganisationId = csm.ReferenceNumber
 				  			AND ppp.FileName = csm.FileName
-            WHERE @IsComplianceScheme = 1             
+            WHERE @IsComplianceScheme = 1
         ) 
 	   ,JsonifiedCompliancePaycalCTE
         AS

--- a/src/EPR.CommonDataService.Data/Scripts/Views/producer-paycal-parameters-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/producer-paycal-parameters-resub.sql
@@ -48,7 +48,7 @@ CREATE VIEW [dbo].[v_ProducerPaycalParameters_resub] AS
             ,COUNT(CASE WHEN cd.Packaging_Activity_OM IN ('Primary', 'Secondary') THEN 1 END) AS OnlineMarketPlaceSubsidiaries
         FROM
             rpd.companydetails cd
-        WHERE cd.Subsidiary_Id IS NOT NULL and leaver_date is null
+        WHERE cd.Subsidiary_Id IS NOT NULL -- and leaver_date is null
         GROUP BY cd.FileName, cd.organisation_id
     )
 	,OrganisationPaycalDetailsCTE AS (


### PR DESCRIPTION
Which are to ignore the leaver_date for subsidiaries when counting them in submission and resubmission scenarios. 

The primary change is to remove the filter '-- and leaver_date is null' from the filter for subsidiaries.

This commit ALSO adjusts the fetch org reg details SP to align it with what is currently in production - the performance enhancements made after R13 made it to main but not the R13 branch.