### PR TITLE
[601604] - Align Subsidiary counts to new rules 

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Views/producer-paycal-parameters-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/producer-paycal-parameters-resub.sql
@@ -48,7 +48,7 @@ CREATE VIEW [dbo].[v_ProducerPaycalParameters_resub] AS
             ,COUNT(CASE WHEN cd.Packaging_Activity_OM IN ('Primary', 'Secondary') THEN 1 END) AS OnlineMarketPlaceSubsidiaries
         FROM
             rpd.companydetails cd
-        WHERE cd.Subsidiary_Id IS NOT NULL and leaver_date is null
+        WHERE cd.Subsidiary_Id IS NOT NULL -- and leaver_date is null
         GROUP BY cd.FileName, cd.organisation_id
     )
 	,OrganisationPaycalDetailsCTE AS (


### PR DESCRIPTION
This is done by removing the filter '-- and leaver_date is null' when counting subsidiaries in the v_ProducerPaycalParameters_resub view.