### PR TITLE
Bug/605896 late fees being applied after registration queried MAIN

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_fetch-organisation-registration-details-resub.sql
@@ -476,12 +476,7 @@ BEGIN
 				,ppp.ProducerSize
 				,csm.SubmittedDate
 				,CASE WHEN csm.IsNewJoiner = 1 THEN csm.IsLateFeeApplicable
-  					  ELSE CASE WHEN csm.organisation_size = 'S' THEN
-									CASE WHEN csm.SubmittedOn > @SmallLateFeeCutoffDate THEN 1 ELSE 0 END
-								WHEN csm.organisation_size = 'L' THEN
-									CASE WHEN csm.SubmittedOn > @CSLLateFeeCutoffDate THEN 1 ELSE 0 END
-								ELSE csm.IsLateSubmission 
-						   END
+					  ELSE csm.IsLateSubmission
 				 END AS IsLateFeeApplicable
 				,csm.OrganisationName
 				,csm.leaver_code


### PR DESCRIPTION
Adjusted [sp_FetchOrganisationRegistrationSubmissionDetails_resub].

Changed the date used for late-fee evaluation from the member's submission date to the actual date of the submission itself. If the Submission itself is before the cut-off date, then no late-fee will be attributable to members even when they are added after the cut-off date.