### PR TITLE
Extend POMM acceptance period in stored proc MAIN

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/get-approved-submissions.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/get-approved-submissions.sql
@@ -15,11 +15,18 @@ GO
 CREATE PROC [dbo].[sp_GetApprovedSubmissions] @ApprovedAfter [DATETIME2],@Periods [VARCHAR](MAX),@IncludePackagingTypes [VARCHAR](MAX),@IncludePackagingMaterials [VARCHAR](MAX),@IncludeOrganisationSize [VARCHAR](MAX) AS
 BEGIN
 
+		DECLARE @start_dt datetime;
+	DECLARE @batch_id INT;
+	DECLARE @cnt int;
+
+	select @batch_id  = ISNULL(max(batch_id),0)+1 from [dbo].[batch_log]
+	set @start_dt = getdate();
+
 -- Check if there are any approved submissions after the specified date
     IF EXISTS (
         SELECT 1
         FROM [rpd].[SubmissionEvents]
-        WHERE TRY_CAST([Created] AS datetime2) > @ApprovedAfter
+        WHERE TRY_CAST([Created] AS datetime2) >= @ApprovedAfter
         AND Decision = 'Accepted'
     )
     BEGIN
@@ -45,8 +52,8 @@ BEGIN
         IF OBJECT_ID('tempdb..#IncludeOrganisationSizeTable') IS NOT NULL DROP TABLE #IncludeOrganisationSizeTable;
         IF OBJECT_ID('tempdb..#ValidOrganisations') IS NOT NULL DROP TABLE #ValidOrganisations;
 
-        -- Get start date for the current year
-        DECLARE @StartDate DATETIME2 = DATEFROMPARTS(YEAR(GETDATE()), 1, 1);
+        -- Get start date based on reporting packaging data rules
+        DECLARE @StartDate DATETIME2 = DATEADD(MONTH, -7, DATEFROMPARTS(YEAR(GETDATE()), 1, 1));
 
         -- Declare parent type
         DECLARE @DirectRegistrantType NVARCHAR(50) = 'DirectRegistrant';
@@ -124,7 +131,7 @@ BEGIN
                 SubmissionId, 
                 MAX(Created) AS Created
             FROM CleanedSubmissionEvents
-            WHERE Created > @StartDate
+            WHERE Created >= @StartDate
             AND Decision = 'Accepted'
             GROUP BY SubmissionId
         ),
@@ -182,7 +189,7 @@ BEGIN
             p.submission_period AS SubmissionPeriod,
             p.packaging_material AS PackagingMaterial,
             CASE
-                WHEN p.subsidiary_id IS NULL THEN CAST(o.ExternalId AS UNIQUEIDENTIFIER)
+                WHEN NULLIF(TRIM(p.subsidiary_id), '') IS NULL THEN CAST(o.ExternalId AS UNIQUEIDENTIFIER)
                 ELSE CAST(o2.ExternalId AS UNIQUEIDENTIFIER)
             END AS OrganisationId,
             f.Created AS Created,
@@ -191,19 +198,21 @@ BEGIN
             p.organisation_id AS SixDigitOrgId,
             p.packaging_type AS PackType,
             CASE
-                WHEN f.ComplianceSchemeId IS NULL THEN CAST(o.ExternalId AS UNIQUEIDENTIFIER)
+                WHEN NULLIF(TRIM(f.ComplianceSchemeId), '') IS NULL THEN CAST(o.ExternalId AS UNIQUEIDENTIFIER)
                 ELSE f.ComplianceSchemeId
             END AS SubmitterId,
             CASE
-                WHEN f.ComplianceSchemeId IS NULL THEN @DirectRegistrantType
+                WHEN NULLIF(TRIM(f.ComplianceSchemeId), '') IS NULL THEN @DirectRegistrantType
                 ELSE @ComplianceSchemeType
             END AS SubmitterType
         INTO #FilteredByApproveAfterYear
         FROM #FileIdss f
-        INNER JOIN FilteredPom p ON f.FileName = p.FileName
-        INNER JOIN [rpd].[Organisations] o ON p.organisation_id = o.ReferenceNumber
-        LEFT JOIN [rpd].[Organisations] o2 ON p.subsidiary_id = o2.ReferenceNumber;
-
+        INNER JOIN FilteredPom p 
+            ON f.FileName = p.FileName
+        INNER JOIN [rpd].[Organisations] o 
+            ON p.organisation_id = o.ReferenceNumber
+        LEFT JOIN [rpd].[Organisations] o2 
+            ON NULLIF(TRIM(p.subsidiary_id), '') = o2.ReferenceNumber;
 
 
         -- Step 7: Identify eligible organisations per period group
@@ -329,7 +338,7 @@ BEGIN
         INTO #ValidOrganisations
         FROM #FileIdss f
         INNER JOIN [rpd].[Pom] p ON p.FileName = f.FileName
-        WHERE TRY_CAST(f.Created AS datetime2) > @ApprovedAfter;
+        WHERE TRY_CAST(f.Created AS datetime2) >= @ApprovedAfter;
 
         -- Step 14: Build final aggregation
         SELECT DISTINCT
@@ -399,5 +408,8 @@ BEGIN
             CAST(NULL AS VARCHAR(50)) AS SubmitterType
         WHERE 1 = 0; -- Ensures no rows are returned
     END
+
+	INSERT INTO [dbo].[batch_log] ([ID],[ProcessName],[SubProcessName],[Count],[start_time_stamp],[end_time_stamp],[Comments],batch_id)
+	select (select ISNULL(max(id),1)+1 from [dbo].[batch_log]),'dbo.sp_GetApprovedSubmissions',@ApprovedAfter, NULL, @start_dt, getdate(), '@ApprovedAfter',@batch_id
 END
 GO


### PR DESCRIPTION
[AB#605786](https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/605786)

This PR extends the POMM acceptance period by calculating a start date six months before the beginning of the current year, aligning with the relevant year’s POMM period. It also adds a check to handle empty or null Subsidiary IDs.