### PR TITLE
ECV-410: Add endpoints to enable data streaming from database (#344)

### DIFF
--- a/src/EPR.CommonDataService.Api.UnitTests/EPR.CommonDataService.Api.UnitTests.csproj
+++ b/src/EPR.CommonDataService.Api.UnitTests/EPR.CommonDataService.Api.UnitTests.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />

--- a/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Organisations/OrganisationsControllerTests.cs
+++ b/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Organisations/OrganisationsControllerTests.cs
@@ -1,0 +1,191 @@
+using EPR.CommonDataService.Api.Configuration;
+using EPR.CommonDataService.Api.Features.PayCal.Organisations;
+using EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+using EPR.CommonDataService.Api.Infrastructure;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.UnitTests.Features.PayCal.Organisations;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class OrganisationsControllerTests
+{
+    private Mock<IStreamOrganisationsRequestHandler> _mockRequestHandler = null!;
+    private Mock<IValidator<StreamOrganisationsRequest>> _mockValidator = null!;
+    private Mock<IOptions<ApiConfig>> _mockApiConfig = null!;
+    private Mock<ILogger<OrganisationsController>> _mockLogger = null!;
+    private OrganisationsController _controller = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockRequestHandler = new Mock<IStreamOrganisationsRequestHandler>();
+        _mockValidator = new Mock<IValidator<StreamOrganisationsRequest>>();
+        _mockLogger = new Mock<ILogger<OrganisationsController>>();
+        _mockApiConfig = new Mock<IOptions<ApiConfig>>();
+
+        _mockApiConfig
+            .Setup(x => x.Value)
+            .Returns(new ApiConfig
+            {
+                BaseProblemTypePath = "https://dummytest/"
+            });
+
+        _controller = new OrganisationsController(
+            _mockRequestHandler.Object,
+            _mockValidator.Object,
+            _mockApiConfig.Object,
+            _mockLogger.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenRequestIsValid_ShouldReturnNdJsonStreamResult()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = 2025 };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        var orgResponses = new List<OrganisationResponse>
+        {
+            new()
+            {
+                OrganisationId = 1,
+                SubsidiaryId = null,
+                OrganisationName = "Test Org",
+                TradingName = "Test Trading",
+                StatusCode = "Active",
+                ErrorCode = null,
+                JoinerDate = "2024-01-01",
+                LeaverDate = null,
+                ObligationStatus = "Obligated",
+                NumDaysObligated = 365,
+                SubmitterId = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            }
+        };
+
+        _mockRequestHandler
+            .Setup(h => h.Handle(request))
+            .Returns(orgResponses.ToAsyncEnumerable());
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NdJsonStreamResult<OrganisationResponse>>();
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenRequestIsInvalid_ShouldReturnValidationProblem()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = null };
+
+        var validationFailures = new List<ValidationFailure>
+        {
+            new("SubmissionYear", "SubmissionYear is required")
+        };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(validationFailures));
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<ObjectResult>();
+        var objectResult = (ObjectResult)result;
+        objectResult.Value.Should().BeOfType<ValidationProblemDetails>();
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenMultipleValidationErrors_ShouldReturnAllErrors()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = 2000 };
+
+        var validationFailures = new List<ValidationFailure>
+        {
+            new("SubmissionYear", "SubmissionYear must be greater than or equal to 2023"),
+            new("SubmissionYear", "Invalid year format")
+        };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(validationFailures));
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<ObjectResult>();
+        var objectResult = (ObjectResult)result;
+        var problemDetails = objectResult.Value as ValidationProblemDetails;
+        problemDetails.Should().NotBeNull();
+        problemDetails!.Errors.Should().ContainKey("SubmissionYear");
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenValidRequest_ShouldReturnNdJsonStreamResultAndCallHandler()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = 2025 };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        _mockRequestHandler
+            .Setup(h => h.Handle(It.IsAny<StreamOrganisationsRequest>()))
+            .Returns(AsyncEnumerable.Empty<OrganisationResponse>());
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NdJsonStreamResult<OrganisationResponse>>();
+        _mockValidator.Verify(
+            v => v.ValidateAsync(request, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockRequestHandler.Verify(
+            h => h.Handle(It.Is<StreamOrganisationsRequest>(r => r.RelativeYear == 2025)),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenValidationFails_ShouldNotCallHandler()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = null };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new List<ValidationFailure>
+            {
+                new("SubmissionYear", "Required")
+            }));
+
+        // Act
+        await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        _mockRequestHandler.Verify(
+            h => h.Handle(It.IsAny<StreamOrganisationsRequest>()),
+            Times.Never);
+    }
+}

--- a/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestHandlerTests.cs
+++ b/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestHandlerTests.cs
@@ -1,0 +1,195 @@
+using EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+using EPR.CommonDataService.Data.Entities;
+using EPR.CommonDataService.Data.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.UnitTests.Features.PayCal.Organisations.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class StreamOrganisationsRequestHandlerTests
+{
+    private SynapseContext _dbContext = null!;
+    private StreamOrganisationsRequestHandler _handler = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<SynapseContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new SynapseContext(options);
+        _handler = new StreamOrganisationsRequestHandler(_dbContext);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _dbContext.Dispose();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenNoOrganisationsExist_ShouldReturnEmptyEnumerable()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<OrganisationResponse>();
+        await foreach (var org in _handler.Handle(request))
+        {
+            results.Add(org);
+        }
+
+        // Assert
+        results.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenOrganisationsExistForYear_ShouldReturnMatchingOrganisations()
+    {
+        // Arrange
+        var orgData = new PayCalOrganisation
+        {
+            OrganisationId = 123,
+            SubsidiaryId = "SUB001",
+            SubmitterId = "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            OrganisationName = "Test Organisation",
+            TradingName = "Test Trading",
+            StatusCode = "Active",
+            ErrorCode = null,
+            JoinerDate = "2025-01-01",
+            LeaverDate = null,
+            ObligationStatus = "Obligated",
+            NumDaysObligated = 365,
+            SubmissionPeriodYear = 2025
+        };
+
+        _dbContext.PayCalOrganisations.Add(orgData);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamOrganisationsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<OrganisationResponse>();
+        await foreach (var org in _handler.Handle(request))
+        {
+            results.Add(org);
+        }
+
+        // Assert
+        results.Should().HaveCount(1);
+        var result = results[0];
+        result.OrganisationId.Should().Be(123);
+        result.SubsidiaryId.Should().Be("SUB001");
+        result.SubmitterId.Should().Be("b2c3d4e5-f6a7-8901-bcde-f12345678901");
+        result.OrganisationName.Should().Be("Test Organisation");
+        result.TradingName.Should().Be("Test Trading");
+        result.StatusCode.Should().Be("Active");
+        result.ErrorCode.Should().BeNull();
+        result.JoinerDate.Should().Be("2025-01-01");
+        result.LeaverDate.Should().BeNull();
+        result.ObligationStatus.Should().Be("Obligated");
+        result.NumDaysObligated.Should().Be(365);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenOrganisationsExistForDifferentYear_ShouldReturnOnlyMatchingYear()
+    {
+        // Arrange
+        var org2025 = new PayCalOrganisation
+        {
+            OrganisationId = 1,
+            OrganisationName = "Org 2025",
+            SubmissionPeriodYear = 2025
+        };
+
+        var org2026 = new PayCalOrganisation
+        {
+            OrganisationId = 2,
+            OrganisationName = "Org 2026",
+            SubmissionPeriodYear = 2026
+        };
+
+        _dbContext.PayCalOrganisations.AddRange(org2025, org2026);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamOrganisationsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<OrganisationResponse>();
+        await foreach (var org in _handler.Handle(request))
+        {
+            results.Add(org);
+        }
+
+        // Assert
+        results.Should().HaveCount(1);
+        var result = results[0];
+        result.OrganisationId.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenMultipleOrganisationsExistForYear_ShouldReturnAllMatchingOrganisations()
+    {
+        // Arrange
+        var orgs = Enumerable.Range(1, 5).Select(i => new PayCalOrganisation
+        {
+            OrganisationId = i,
+            OrganisationName = $"Organisation {i}",
+            SubmissionPeriodYear = 2025
+        }).ToList();
+
+        _dbContext.PayCalOrganisations.AddRange(orgs);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamOrganisationsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<OrganisationResponse>();
+        await foreach (var org in _handler.Handle(request))
+        {
+            results.Add(org);
+        }
+
+        // Assert
+        results.Should().HaveCount(5);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenCancellationRequested_ShouldStopEnumeration()
+    {
+        // Arrange
+        var orgs = Enumerable.Range(1, 10).Select(i => new PayCalOrganisation
+        {
+            OrganisationId = i,
+            OrganisationName = $"Organisation {i}",
+            SubmissionPeriodYear = 2025
+        }).ToList();
+
+        _dbContext.PayCalOrganisations.AddRange(orgs);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamOrganisationsRequest { RelativeYear = 2025 };
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        var results = new List<OrganisationResponse>();
+        var count = 0;
+        await foreach (var org in _handler.Handle(request).WithCancellation(cts.Token))
+        {
+            results.Add(org);
+            count++;
+            if (count >= 3)
+            {
+                await cts.CancelAsync();
+                break;
+            }
+        }
+
+        // Assert
+        results.Should().HaveCount(3);
+    }
+}

--- a/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestValidatorTests.cs
+++ b/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestValidatorTests.cs
@@ -1,0 +1,77 @@
+using EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+using FluentValidation.TestHelper;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.UnitTests.Features.PayCal.Organisations.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class StreamOrganisationsRequestValidatorTests
+{
+    private StreamOrganisationsRequestValidator _validator = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _validator = new StreamOrganisationsRequestValidator();
+    }
+
+    [TestMethod]
+    public void Validate_WhenSubmissionYearIsNull_ShouldHaveValidationError()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = null };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.RelativeYear);
+    }
+
+    [TestMethod]
+    [DataRow(2025)]
+    [DataRow(2026)]
+    [DataRow(9999)]
+    public void Validate_WhenSubmissionYearIsValid_ShouldNotHaveValidationError(int year)
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = year };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.RelativeYear);
+    }
+
+    [TestMethod]
+    [DataRow(2024)]
+    [DataRow(2000)]
+    [DataRow(0)]
+    [DataRow(-1)]
+    public void Validate_WhenSubmissionYearIsLessThan2025_ShouldHaveValidationError(int year)
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = year };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.RelativeYear);
+    }
+
+    [TestMethod]
+    public void Validate_WhenSubmissionYearIsGreaterThan9999_ShouldHaveValidationError()
+    {
+        // Arrange
+        var request = new StreamOrganisationsRequest { RelativeYear = 10000 };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.RelativeYear);
+    }
+}

--- a/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Poms/PomsControllerTests.cs
+++ b/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Poms/PomsControllerTests.cs
@@ -1,0 +1,189 @@
+using EPR.CommonDataService.Api.Configuration;
+using EPR.CommonDataService.Api.Features.PayCal.Poms;
+using EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+using EPR.CommonDataService.Api.Infrastructure;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.UnitTests.Features.PayCal.Poms;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class PomsControllerTests
+{
+    private Mock<IStreamPomsRequestHandler> _mockRequestHandler = null!;
+    private Mock<IValidator<StreamPomsRequest>> _mockValidator = null!;
+    private Mock<IOptions<ApiConfig>> _mockApiConfig = null!;
+    private Mock<ILogger<PomsController>> _mockLogger = null!;
+    private PomsController _controller = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockRequestHandler = new Mock<IStreamPomsRequestHandler>();
+        _mockValidator = new Mock<IValidator<StreamPomsRequest>>();
+        _mockLogger = new Mock<ILogger<PomsController>>();
+        _mockApiConfig = new Mock<IOptions<ApiConfig>>();
+
+        _mockApiConfig
+            .Setup(x => x.Value)
+            .Returns(new ApiConfig
+            {
+                BaseProblemTypePath = "https://dummytest/"
+            });
+
+        _controller = new PomsController(
+            _mockRequestHandler.Object,
+            _mockValidator.Object,
+            _mockApiConfig.Object,
+            _mockLogger.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenRequestIsValid_ShouldReturnNdJsonStreamResult()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = 2025 };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        var pomResponses = new List<PomResponse>
+        {
+            new()
+            {
+                SubmissionPeriod = "2024-P1",
+                OrganisationId = 1,
+                SubsidiaryId = null,
+                PackagingType = "Household",
+                PackagingMaterial = "Plastic",
+                PackagingMaterialWeight = 100,
+                PackagingClass = "ClassA",
+                PackagingActivity = "Primary",
+                SubmitterId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            }
+        };
+
+        _mockRequestHandler
+            .Setup(h => h.Handle(request))
+            .Returns(pomResponses.ToAsyncEnumerable());
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NdJsonStreamResult<PomResponse>>();
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenRequestIsInvalid_ShouldReturnValidationProblem()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = null };
+
+        var validationFailures = new List<ValidationFailure>
+        {
+            new("SubmissionYear", "SubmissionYear is required")
+        };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(validationFailures));
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<ObjectResult>();
+        var objectResult = (ObjectResult)result;
+        objectResult.Value.Should().BeOfType<ValidationProblemDetails>();
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenMultipleValidationErrors_ShouldReturnAllErrors()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = 2000 };
+
+        var validationFailures = new List<ValidationFailure>
+        {
+            new("SubmissionYear", "SubmissionYear must be greater than or equal to 2024"),
+            new("SubmissionYear", "Invalid year format")
+        };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(validationFailures));
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<ObjectResult>();
+        var objectResult = (ObjectResult)result;
+        var problemDetails = objectResult.Value as ValidationProblemDetails;
+        problemDetails.Should().NotBeNull();
+        problemDetails!.Errors.Should().ContainKey("SubmissionYear");
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenValidRequest_ShouldReturnNdJsonStreamResultAndCallHandler()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = 2025 };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        _mockRequestHandler
+            .Setup(h => h.Handle(It.IsAny<StreamPomsRequest>()))
+            .Returns(AsyncEnumerable.Empty<PomResponse>());
+
+        // Act
+        var result = await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NdJsonStreamResult<PomResponse>>();
+        _mockValidator.Verify(
+            v => v.ValidateAsync(request, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockRequestHandler.Verify(
+            h => h.Handle(It.Is<StreamPomsRequest>(r => r.RelativeYear == 2025)),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task StreamOut_WhenValidationFails_ShouldNotCallHandler()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = null };
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new List<ValidationFailure>
+            {
+                new("SubmissionYear", "Required")
+            }));
+
+        // Act
+        await _controller.StreamOut(request, CancellationToken.None);
+
+        // Assert
+        _mockRequestHandler.Verify(
+            h => h.Handle(It.IsAny<StreamPomsRequest>()),
+            Times.Never);
+    }
+}

--- a/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Poms/StreamOut/StreamPomsRequestHandlerTests.cs
+++ b/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Poms/StreamOut/StreamPomsRequestHandlerTests.cs
@@ -1,0 +1,195 @@
+using EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+using EPR.CommonDataService.Data.Entities;
+using EPR.CommonDataService.Data.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.UnitTests.Features.PayCal.Poms.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class StreamPomsRequestHandlerTests
+{
+    private SynapseContext _dbContext = null!;
+    private StreamPomsRequestHandler _handler = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<SynapseContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new SynapseContext(options);
+        _handler = new StreamPomsRequestHandler(_dbContext);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _dbContext.Dispose();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenNoPomsExist_ShouldReturnEmptyEnumerable()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<PomResponse>();
+        await foreach (var pom in _handler.Handle(request))
+        {
+            results.Add(pom);
+        }
+
+        // Assert
+        results.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenPomsExistForYear_ShouldReturnMatchingPoms()
+    {
+        // Arrange
+        var pomData = new PayCalPom
+        {
+            OrganisationId = 123,
+            SubsidiaryId = "SUB001",
+            SubmitterId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            SubmissionPeriod = "2024-P1",
+            PackagingActivity = "Primary",
+            PackagingType = "Household",
+            PackagingClass = "ClassA",
+            PackagingMaterial = "Plastic",
+            PackagingMaterialWeight = 100.5
+        };
+
+        _dbContext.PayCalPoms.Add(pomData);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamPomsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<PomResponse>();
+        await foreach (var pom in _handler.Handle(request))
+        {
+            results.Add(pom);
+        }
+
+        // Assert
+        results.Should().HaveCount(1);
+        var result = results[0];
+        result.OrganisationId.Should().Be(123);
+        result.SubsidiaryId.Should().Be("SUB001");
+        result.SubmitterId.Should().Be("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+        result.SubmissionPeriod.Should().Be("2024-P1");
+        result.PackagingActivity.Should().Be("Primary");
+        result.PackagingType.Should().Be("Household");
+        result.PackagingClass.Should().Be("ClassA");
+        result.PackagingMaterial.Should().Be("Plastic");
+        result.PackagingMaterialWeight.Should().Be(100.5);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenPomsExistForDifferentYear_ShouldReturnOnlyMatchingYear()
+    {
+        // Arrange
+        var pom2024 = new PayCalPom
+        {
+            OrganisationId = 1,
+            SubmissionPeriod = "2024-P1",
+            PackagingType = "Household",
+            PackagingMaterial = "Plastic"
+        };
+
+        var pom2025 = new PayCalPom
+        {
+            OrganisationId = 2,
+            SubmissionPeriod = "2025-P1",
+            PackagingType = "Household",
+            PackagingMaterial = "Plastic"
+        };
+
+        _dbContext.PayCalPoms.AddRange(pom2024, pom2025);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamPomsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<PomResponse>();
+        await foreach (var pom in _handler.Handle(request))
+        {
+            results.Add(pom);
+        }
+
+        // Assert
+        results.Should().HaveCount(1);
+        var result = results[0];
+        result.OrganisationId.Should().Be(1);
+        result.SubmissionPeriod.Should().StartWith("2024");
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenMultiplePomsExistForYear_ShouldReturnAllMatchingPoms()
+    {
+        // Arrange
+        var poms = Enumerable.Range(1, 5).Select(i => new PayCalPom
+        {
+            OrganisationId = i,
+            SubmissionPeriod = "2024-P1",
+            PackagingType = $"Type{i}",
+            PackagingMaterial = $"Material{i}"
+        }).ToList();
+
+        _dbContext.PayCalPoms.AddRange(poms);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamPomsRequest { RelativeYear = 2025 };
+
+        // Act
+        var results = new List<PomResponse>();
+        await foreach (var pom in _handler.Handle(request))
+        {
+            results.Add(pom);
+        }
+
+        // Assert
+        results.Should().HaveCount(5);
+    }
+
+    [TestMethod]
+    public async Task Handle_WhenCancellationRequested_ShouldStopEnumeration()
+    {
+        // Arrange
+        var poms = Enumerable.Range(1, 10).Select(i => new PayCalPom
+        {
+            OrganisationId = i,
+            SubmissionPeriod = "2024-P1",
+            PackagingType = $"Type{i}",
+            PackagingMaterial = $"Material{i}"
+        }).ToList();
+
+        _dbContext.PayCalPoms.AddRange(poms);
+        await _dbContext.SaveChangesAsync();
+
+        var request = new StreamPomsRequest { RelativeYear = 2025 };
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        var results = new List<PomResponse>();
+        var count = 0;
+        await foreach (var pom in _handler.Handle(request).WithCancellation(cts.Token))
+        {
+            results.Add(pom);
+            count++;
+            if (count >= 3)
+            {
+                await cts.CancelAsync();
+                break;
+            }
+        }
+
+        // Assert
+        results.Should().HaveCount(3);
+    }
+}

--- a/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Poms/StreamOut/StreamPomsRequestValidatorTests.cs
+++ b/src/EPR.CommonDataService.Api.UnitTests/Features/PayCal/Poms/StreamOut/StreamPomsRequestValidatorTests.cs
@@ -1,0 +1,77 @@
+using EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+using FluentValidation.TestHelper;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.UnitTests.Features.PayCal.Poms.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class StreamPomsRequestValidatorTests
+{
+    private StreamPomsRequestValidator _validator = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _validator = new StreamPomsRequestValidator();
+    }
+
+    [TestMethod]
+    public void Validate_WhenSubmissionYearIsNull_ShouldHaveValidationError()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = null };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.RelativeYear);
+    }
+
+    [TestMethod]
+    [DataRow(2025)]
+    [DataRow(2026)]
+    [DataRow(9999)]
+    public void Validate_WhenSubmissionYearIsValid_ShouldNotHaveValidationError(int year)
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = year };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.RelativeYear);
+    }
+
+    [TestMethod]
+    [DataRow(2024)]
+    [DataRow(2000)]
+    [DataRow(0)]
+    [DataRow(-1)]
+    public void Validate_WhenSubmissionYearIsLessThan2025_ShouldHaveValidationError(int year)
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = year };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.RelativeYear);
+    }
+
+    [TestMethod]
+    public void Validate_WhenSubmissionYearIsGreaterThan9999_ShouldHaveValidationError()
+    {
+        // Arrange
+        var request = new StreamPomsRequest { RelativeYear = 10000 };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.RelativeYear);
+    }
+}

--- a/src/EPR.CommonDataService.Api.UnitTests/Infrastructure/NdJsonStreamResultTests.cs
+++ b/src/EPR.CommonDataService.Api.UnitTests/Infrastructure/NdJsonStreamResultTests.cs
@@ -1,0 +1,490 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using EPR.CommonDataService.Api.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+
+namespace EPR.CommonDataService.Api.UnitTests.Infrastructure;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class NdJsonStreamResultTests
+{
+    private DefaultHttpContext _httpContext = null!;
+    private ActionContext _actionContext = null!;
+    private MemoryStream _responseBody = null!;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _responseBody = new MemoryStream();
+        _httpContext = new DefaultHttpContext
+        {
+            Response =
+            {
+                Body = _responseBody
+            }
+        };
+        _actionContext = new ActionContext
+        {
+            HttpContext = _httpContext
+        };
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        _responseBody.Dispose();
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldSetCorrectContentType()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _httpContext.Response.ContentType.Should().Be("application/x-ndjson; charset=utf-8");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldSetCacheControlHeader()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _httpContext.Response.Headers[HeaderNames.CacheControl].ToString().Should().Be("no-store");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldSetAccelBufferingHeader()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _httpContext.Response.Headers["X-Accel-Buffering"].ToString().Should().Be("no");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithEmptyEnumerable_ShouldInvokeCallbackWithZeroCount()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        long callbackCount = -1;
+        TimeSpan callbackDuration = TimeSpan.Zero;
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords(), r =>
+        {
+            callbackCount = r.RecordsStreamed;
+            callbackDuration = r.Duration;
+        });
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        callbackCount.Should().Be(0);
+        callbackDuration.Should().BeGreaterOrEqualTo(TimeSpan.Zero);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithSingleRecord_ShouldInvokeCallbackWithCountOfOne()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = "Test" };
+        }
+
+        long callbackCount = -1;
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords(), r =>
+        {
+            callbackCount = r.RecordsStreamed;
+        });
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        callbackCount.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithMultipleRecords_ShouldInvokeCallbackWithCorrectCount()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = "First" };
+            yield return new TestRecord { Id = 2, Name = "Second" };
+            yield return new TestRecord { Id = 3, Name = "Third" };
+        }
+
+        long callbackCount = -1;
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords(), r =>
+        {
+            callbackCount = r.RecordsStreamed;
+        });
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        callbackCount.Should().Be(3);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldSerializeRecordsAsNewlineDelimitedJson()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = "First" };
+            yield return new TestRecord { Id = 2, Name = "Second" };
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _responseBody.Position = 0;
+        var content = Encoding.UTF8.GetString(_responseBody.ToArray());
+        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        lines.Should().HaveCount(2);
+        lines[0].Should().Be("{\"id\":1,\"name\":\"First\"}");
+        lines[1].Should().Be("{\"id\":2,\"name\":\"Second\"}");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldUseCamelCasePropertyNames()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecordWithPascalCase> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecordWithPascalCase { RecordId = 1, FullName = "Test" };
+        }
+
+        var result = new NdJsonStreamResult<TestRecordWithPascalCase>(GetRecords());
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _responseBody.Position = 0;
+        var content = Encoding.UTF8.GetString(_responseBody.ToArray());
+
+        content.Should().Contain("\"recordId\":1");
+        content.Should().Contain("\"fullName\":\"Test\"");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldIgnoreNullValues()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = null };
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _responseBody.Position = 0;
+        var content = Encoding.UTF8.GetString(_responseBody.ToArray());
+
+        content.Should().NotContain("name");
+        content.Trim().Should().Be("{\"id\":1}");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldInvokeCallbackWithDuration()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.Delay(10);
+            yield return new TestRecord { Id = 1, Name = "Test" };
+        }
+
+        TimeSpan callbackDuration = TimeSpan.Zero;
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords(), r =>
+        {
+            callbackDuration = r.Duration;
+        });
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        callbackDuration.Should().BeGreaterThan(TimeSpan.Zero);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithCancellation_ShouldStopProcessing()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var recordsYielded = 0;
+
+        async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                await Task.Delay(10, cts.Token);
+                recordsYielded++;
+                yield return new TestRecord { Id = i, Name = $"Record{i}" };
+
+                if (i == 2)
+                {
+                    // ReSharper disable once AccessToDisposedClosure
+                    await cts.CancelAsync();
+                }
+            }
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+        _httpContext.RequestAborted = cts.Token;
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        recordsYielded.Should().BeLessThan(100);
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithCancellation_ShouldReportAbortedInResult()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        NdJsonStreamResult<TestRecord>.Result? callbackResult = null;
+
+        async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            yield return new TestRecord { Id = 1, Name = "First" };
+            yield return new TestRecord { Id = 2, Name = "Second" };
+            await cts.CancelAsync();
+            await Task.Delay(10, cts.Token); // will throw
+            yield return new TestRecord { Id = 3, Name = "Third" };
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(
+            GetRecords(),
+            r => callbackResult = r);
+        _httpContext.RequestAborted = cts.Token;
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        callbackResult.Should().NotBeNull();
+        callbackResult!.WasAbortedByClient.Should().BeTrue();
+        callbackResult.RecordsStreamed.Should().Be(2);
+        callbackResult.Duration.Should().BeGreaterOrEqualTo(TimeSpan.Zero);
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithError_ShouldInvokeCallbackThenThrow()
+    {
+        // Arrange
+        NdJsonStreamResult<TestRecord>.Result? callbackResult = null;
+
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = "First" };
+            yield return new TestRecord { Id = 2, Name = "Second" };
+            throw new InvalidOperationException("Simulated DB failure");
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(
+            GetRecords(),
+            r => callbackResult = r);
+
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => result.ExecuteResultAsync(_actionContext));
+
+        callbackResult.Should().NotBeNull();
+        callbackResult!.WasAbortedByClient.Should().BeFalse();
+        callbackResult.RecordsStreamed.Should().Be(2);
+        callbackResult.Duration.Should().BeGreaterOrEqualTo(TimeSpan.Zero);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithErrorOnFirstRecord_ShouldReportZeroCount()
+    {
+        // Arrange
+        NdJsonStreamResult<TestRecord>.Result? callbackResult = null;
+
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            yield return await Task.FromException<TestRecord>(new InvalidOperationException("immediate failure"));
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(
+            GetRecords(),
+            r => callbackResult = r);
+
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => result.ExecuteResultAsync(_actionContext));
+
+        callbackResult.Should().NotBeNull();
+        callbackResult!.RecordsStreamed.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WhenSuccessful_ShouldReportNotAborted()
+    {
+        // Arrange
+        NdJsonStreamResult<TestRecord>.Result? callbackResult = null;
+
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = "Test" };
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(
+            GetRecords(),
+            r => callbackResult = r);
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        callbackResult.Should().NotBeNull();
+        callbackResult!.WasAbortedByClient.Should().BeFalse();
+        callbackResult.RecordsStreamed.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_ShouldEndEachLineWithNewline()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = "Test" };
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _responseBody.Position = 0;
+        var content = Encoding.UTF8.GetString(_responseBody.ToArray());
+
+        content.Should().EndWith("\n");
+    }
+
+    [TestMethod]
+    public void Constructor_WithNullDataSource_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        var act = () => new NdJsonStreamResult<TestRecord>(null!);
+        
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("dataSource");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithNullActionContext_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords());
+
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            await result.ExecuteResultAsync(null!));
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsync_WithNoCallback_ShouldCompleteSuccessfully()
+    {
+        // Arrange
+        static async IAsyncEnumerable<TestRecord> GetRecords()
+        {
+            await Task.CompletedTask;
+            yield return new TestRecord { Id = 1, Name = "Test" };
+        }
+
+        var result = new NdJsonStreamResult<TestRecord>(GetRecords(), onComplete: null);
+
+        // Act
+        await result.ExecuteResultAsync(_actionContext);
+
+        // Assert
+        _responseBody.Position = 0;
+        var content = Encoding.UTF8.GetString(_responseBody.ToArray());
+        content.Should().Contain("\"id\":1");
+    }
+
+    private class TestRecord
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+
+    private class TestRecordWithPascalCase
+    {
+        public int RecordId { get; set; }
+        public string? FullName { get; set; }
+    }
+}

--- a/src/EPR.CommonDataService.Api/Configuration/ApiRateLimitOptions.cs
+++ b/src/EPR.CommonDataService.Api/Configuration/ApiRateLimitOptions.cs
@@ -1,0 +1,64 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.Configuration;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("ReSharper", "CollectionNeverUpdated.Global")]
+[SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
+public sealed record ApiRateLimitOptions
+{
+    public const string ConfigSection = "ApiConfig:RateLimiting";
+
+    public const string PayCalOrganisationsStreamPolicy = "GET /api/paycal/organisations/stream";
+    public const string PayCalPomsStreamPolicy = "GET /api/paycal/poms/stream";
+
+    /// <summary>
+    ///     Allows the limiter to be disabled for all policies.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    public Dictionary<string, ConcurrentLimitPolicy> Policies { get; init; }
+        = new(new PolicyNameComparer());
+
+    public sealed record ConcurrentLimitPolicy
+    {
+        /// <summary>
+        ///     Allows the limiter to be disabled on a per-policy basis.
+        /// </summary>
+        public bool Enabled { get; init; } = true;
+
+        /// <summary>
+        ///     Maximum number of permits that can be leased concurrently.
+        /// </summary>
+        [Range(1, int.MaxValue)]
+        public int PermitLimit { get; init; } = 1;
+
+        /// <summary>
+        ///     Maximum number of permits that can be queued concurrently.
+        /// </summary>
+        [Range(0, int.MaxValue)]
+        public int QueueLimit { get; init; } = 0;
+    }
+
+    /// <summary>
+    ///     Handles any casing/trailing slash issues in input policy names.
+    /// </summary>
+    private sealed class PolicyNameComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string? x, string? y)
+        {
+            return string.Equals(Canonical(x), Canonical(y), StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(Canonical(obj));
+        }
+
+        private static string Canonical(string? s)
+        {
+            return s?.Trim().TrimEnd('/') ?? string.Empty;
+        }
+    }
+}

--- a/src/EPR.CommonDataService.Api/EPR.CommonDataService.Api.csproj
+++ b/src/EPR.CommonDataService.Api/EPR.CommonDataService.Api.csproj
@@ -16,6 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
+++ b/src/EPR.CommonDataService.Api/Extensions/ServiceProviderExtensions.cs
@@ -1,18 +1,29 @@
-﻿using EPR.CommonDataService.Api.Configuration;
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
+using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
+using EPR.CommonDataService.Api.Configuration;
+using EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+using EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
 using EPR.CommonDataService.Core.Services;
 using EPR.CommonDataService.Data.Infrastructure;
-using Microsoft.EntityFrameworkCore;
-using System.Text.Json.Serialization;
+using FluentValidation;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace EPR.CommonDataService.Api.Extensions;
 
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+[ExcludeFromCodeCoverage]
 public static class ServiceProviderExtensions
 {
     private const string BaseProblemTypePath = "ApiConfig:BaseProblemTypePath";
     public static IServiceCollection RegisterWebComponents(this IServiceCollection services, IConfiguration configuration)
     {
+        AddResponseCompression(services);
+        AddRateLimiter(services, configuration);
         AddControllers(services, configuration);
         ConfigureOptions(services, configuration);
         RegisterServices(services);
@@ -20,7 +31,8 @@ public static class ServiceProviderExtensions
         return services;
     }
 
-    public static IServiceCollection RegisterDataComponents(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection RegisterDataComponents(this IServiceCollection services,
+        IConfiguration configuration)
     {
         services.AddDbContext<SynapseContext>(options =>
         {
@@ -44,9 +56,65 @@ public static class ServiceProviderExtensions
             {
                 options.UseSqlServer(connectionString);
             }
+
+            options.AddInterceptors(new TimeoutInterceptor());
         });
 
         return services;
+    }
+
+    private static void AddResponseCompression(IServiceCollection services)
+    {
+        services.AddResponseCompression(options =>
+        {
+            options.EnableForHttps = true;
+            options.Providers.Add<GzipCompressionProvider>();
+            options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(["application/x-ndjson"]);
+        });
+
+        services.Configure<GzipCompressionProviderOptions>(options =>
+        {
+            options.Level = CompressionLevel.Fastest;
+        });
+    }
+
+    private static void AddRateLimiter(IServiceCollection services, IConfiguration configuration)
+    {
+        services
+            .AddOptionsWithValidateOnStart<ApiRateLimitOptions>()
+            .Bind(configuration.GetSection(ApiRateLimitOptions.ConfigSection))
+            .ValidateDataAnnotations();
+
+        services
+            .AddOptions<RateLimiterOptions>()
+            .Configure<IOptions<ApiRateLimitOptions>>((options, apiRateLimits) =>
+            {
+                options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+                AddLimiter(ApiRateLimitOptions.PayCalOrganisationsStreamPolicy);
+                AddLimiter(ApiRateLimitOptions.PayCalPomsStreamPolicy);
+
+                void AddLimiter(string policyName)
+                {
+                    var policy = apiRateLimits.Value.Policies
+                        .GetValueOrDefault(policyName, new ApiRateLimitOptions.ConcurrentLimitPolicy());
+
+                    if (!apiRateLimits.Value.Enabled || !policy.Enabled)
+                    {
+                        // We still need a policy to be registered otherwise the endpoint will error when called.
+                        options.AddPolicy(policyName, _ => RateLimitPartition.GetNoLimiter(string.Empty));
+                        return;
+                    }
+
+                    options.AddConcurrencyLimiter(policyName, limiterOpts =>
+                    {
+                        limiterOpts.PermitLimit = policy.PermitLimit;
+                        limiterOpts.QueueLimit = policy.QueueLimit;
+                    });
+                }
+            });
+
+        services.AddRateLimiter(_ => { });
     }
 
     private static void AddControllers(IServiceCollection services, IConfiguration configuration)
@@ -76,10 +144,13 @@ public static class ServiceProviderExtensions
 
     private static void RegisterServices(IServiceCollection services)
     {
+        services.AddValidatorsFromAssemblyContaining(typeof(Program));
         services.AddScoped<IRegistrationFeeCalculationDetailsService, RegistrationFeeCalculationDetailsService>();
         services.AddScoped<IProducerDetailsService, ProducerDetailsService>();
         services.AddScoped<ISubmissionEventService, SubmissionEventService>();
         services.AddScoped<ISubmissionsService, SubmissionsService>();
         services.AddScoped<IDatabaseTimeoutService, DatabaseTimeoutService>();
+        services.AddScoped<IStreamOrganisationsRequestHandler, StreamOrganisationsRequestHandler>();
+        services.AddScoped<IStreamPomsRequestHandler, StreamPomsRequestHandler>();
     }
 }

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/OrganisationsController.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/OrganisationsController.cs
@@ -1,0 +1,56 @@
+using System.Net.Mime;
+using EPR.CommonDataService.Api.Configuration;
+using EPR.CommonDataService.Api.Controllers;
+using EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+using EPR.CommonDataService.Api.Infrastructure;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Organisations;
+
+[ApiController]
+[Route("api/paycal/organisations")]
+public sealed class OrganisationsController(
+    IStreamOrganisationsRequestHandler requestHandler,
+    IValidator<StreamOrganisationsRequest> requestValidator,
+    IOptions<ApiConfig> apiConfig,
+    ILogger<OrganisationsController> logger)
+    : ApiControllerBase(apiConfig)
+{
+    [HttpGet("stream")]
+    [EnableRateLimiting(ApiRateLimitOptions.PayCalOrganisationsStreamPolicy)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status200OK, "application/x-ndjson")] // typeof(void) as NDJSON stream can't be represented in OpenAPI spec
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest, MediaTypeNames.Application.ProblemJson)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> StreamOut([FromQuery] StreamOrganisationsRequest request,
+        CancellationToken cancellationToken)
+    {
+        // Reject if request is invalid as the underlying DB calls are expensive
+        var validationResult = await requestValidator.ValidateAsync(request, cancellationToken);
+
+        if (!validationResult.IsValid)
+        {
+            logger.LogInformation("StreamOut: Invalid request. Errors={Errors}",
+                string.Join("; ", validationResult.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}")));
+
+            foreach (var error in validationResult.Errors)
+                ModelState.AddModelError(error.PropertyName, error.ErrorMessage);
+
+            return ValidationProblem();
+        }
+
+        logger.LogInformation("StreamOut: Starting. Request={Request}", request);
+
+        return new NdJsonStreamResult<OrganisationResponse>(
+            requestHandler.Handle(request),
+            result =>
+            {
+                var status = result.WasAbortedByClient ? "Aborted by client" : "Completed successfully";
+
+                logger.LogInformation("StreamOut: Finished. Status={Status} RecordsStreamed={RecordsStreamed} Duration={Duration}",
+                    status, result.RecordsStreamed, result.Duration.ToString("g"));
+            });
+    }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/OrganisationResponse.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/OrganisationResponse.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+public sealed record OrganisationResponse
+{
+    public int OrganisationId { get; init; }
+    public string? SubsidiaryId { get; init; }
+    public string? OrganisationName { get; init; }
+    public string? TradingName { get; init; }
+    public string? StatusCode { get; init; }
+    public string? ErrorCode { get; init; }
+    public string? JoinerDate { get; init; }
+    public string? LeaverDate { get; init; }
+    public string? ObligationStatus { get; init; }
+    public short? NumDaysObligated { get; init; }
+    public string? SubmitterId { get; init; }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequest.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequest.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+public sealed record StreamOrganisationsRequest
+{
+    /// <summary>
+    ///     The PayCal relative year to retrieve Organisations against.
+    ///     Must be a 4 digit year that is valid for the scheme.
+    ///     Required.
+    /// </summary>
+    /// <remarks>
+    ///     Organisations returned will have a SubmissionYear equal to RelativeYear.
+    /// </remarks>
+    public required int? RelativeYear { get; init; }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestHandler.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestHandler.cs
@@ -1,0 +1,38 @@
+using EPR.CommonDataService.Data.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+
+public interface IStreamOrganisationsRequestHandler
+{
+    IAsyncEnumerable<OrganisationResponse> Handle(StreamOrganisationsRequest request);
+}
+
+public sealed class StreamOrganisationsRequestHandler(SynapseContext dbContext)
+    : IStreamOrganisationsRequestHandler
+{
+    public async IAsyncEnumerable<OrganisationResponse> Handle(StreamOrganisationsRequest request)
+    {
+        var organisations = dbContext
+            .PayCalOrganisations
+            .AsNoTracking()
+            .Where(org => org.SubmissionPeriodYear == request.RelativeYear)
+            .AsAsyncEnumerable();
+
+        await foreach (var org in organisations)
+            yield return new OrganisationResponse
+            {
+                OrganisationId = org.OrganisationId!.Value,
+                SubsidiaryId = org.SubsidiaryId,
+                OrganisationName = org.OrganisationName!,
+                TradingName = org.TradingName,
+                StatusCode = org.StatusCode,
+                ErrorCode = org.ErrorCode,
+                JoinerDate = org.JoinerDate,
+                LeaverDate = org.LeaverDate,
+                ObligationStatus = org.ObligationStatus,
+                NumDaysObligated = org.NumDaysObligated,
+                SubmitterId = org.SubmitterId
+            };
+    }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestValidator.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Organisations/StreamOut/StreamOrganisationsRequestValidator.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Organisations.StreamOut;
+
+public sealed class StreamOrganisationsRequestValidator
+    : AbstractValidator<StreamOrganisationsRequest>
+{
+    public StreamOrganisationsRequestValidator()
+    {
+        RuleFor(request => request.RelativeYear)
+            .NotNull()
+            .GreaterThanOrEqualTo(2025) // First valid EPR year
+            .LessThanOrEqualTo(9999);
+    }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Poms/PomsController.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Poms/PomsController.cs
@@ -1,0 +1,56 @@
+using System.Net.Mime;
+using EPR.CommonDataService.Api.Configuration;
+using EPR.CommonDataService.Api.Controllers;
+using EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+using EPR.CommonDataService.Api.Infrastructure;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Poms;
+
+[ApiController]
+[Route("api/paycal/poms")]
+public sealed class PomsController(
+    IStreamPomsRequestHandler requestHandler,
+    IValidator<StreamPomsRequest> requestValidator,
+    IOptions<ApiConfig> apiConfig,
+    ILogger<PomsController> logger)
+    : ApiControllerBase(apiConfig)
+{
+    [HttpGet("stream")]
+    [EnableRateLimiting(ApiRateLimitOptions.PayCalPomsStreamPolicy)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status200OK, "application/x-ndjson")] // typeof(void) as NDJSON stream can't be represented in OpenAPI spec
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest, MediaTypeNames.Application.ProblemJson)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> StreamOut([FromQuery] StreamPomsRequest request,
+        CancellationToken cancellationToken)
+    {
+        // Reject if request is invalid as the underlying DB calls are expensive
+        var validationResult = await requestValidator.ValidateAsync(request, cancellationToken);
+
+        if (!validationResult.IsValid)
+        {
+            logger.LogInformation("StreamOut: Invalid request. Errors={Errors}",
+                string.Join("; ", validationResult.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}")));
+
+            foreach (var error in validationResult.Errors)
+                ModelState.AddModelError(error.PropertyName, error.ErrorMessage);
+
+            return ValidationProblem();
+        }
+
+        logger.LogInformation("StreamOut: Starting. Request={Request}", request);
+
+        return new NdJsonStreamResult<PomResponse>(
+            requestHandler.Handle(request),
+            result =>
+            {
+                var status = result.WasAbortedByClient ? "Aborted by client" : "Completed successfully";
+
+                logger.LogInformation("StreamOut: Finished. Status={Status} RecordsStreamed={RecordsStreamed} Duration={Duration}",
+                    status, result.RecordsStreamed, result.Duration.ToString("g"));
+            });
+    }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/PomResponse.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/PomResponse.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+public sealed record PomResponse
+{
+    public string? SubmissionPeriod { get; init; }
+    public string? SubmissionPeriodDescription { get; init; }
+    public int OrganisationId { get; init; }
+    public string? SubsidiaryId { get; init; }
+    public string? PackagingType { get; init; }
+    public string? PackagingMaterial { get; init; }
+    public double? PackagingMaterialWeight { get; init; }
+    public string? PackagingClass { get; init; }
+    public string? PackagingActivity { get; init; }
+    public string? SubmitterId { get; init; }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/StreamPomsRequest.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/StreamPomsRequest.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+public sealed record StreamPomsRequest
+{
+    /// <summary>
+    ///     The PayCal relative year to retrieve POMs against.
+    ///     Must be a 4 digit year that is valid for the scheme.
+    ///     Required.
+    /// </summary>
+    /// <remarks>
+    ///     POMs returned will have a SubmissionYear one year PRIOR to RelativeYear.
+    /// </remarks>
+    public required int? RelativeYear { get; init; }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/StreamPomsRequestHandler.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/StreamPomsRequestHandler.cs
@@ -1,0 +1,44 @@
+using EPR.CommonDataService.Data.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+
+public interface IStreamPomsRequestHandler
+{
+    IAsyncEnumerable<PomResponse> Handle(StreamPomsRequest request);
+}
+
+public sealed class StreamPomsRequestHandler(SynapseContext dbContext)
+    : IStreamPomsRequestHandler
+{
+    public async IAsyncEnumerable<PomResponse> Handle(StreamPomsRequest request)
+    {
+        // SQL filter to match all POM SubmissionPeriods for the requested RelativeYear.
+        // For POMs this should be the year prior to RelativeYear.
+        var filter = $"{request.RelativeYear - 1}%";
+
+        var poms = dbContext
+            .PayCalPoms
+            .WithTimeout(TimeSpan.FromMinutes(10)) // Necessary due to the poor performance of the underlying view
+            .AsNoTracking()
+            // ReSharper disable once EntityFramework.ClientSideDbFunctionCall - Incorrect analysis result (due to WithTimeout extension method)
+            // Synapse requires use of EF.Functions
+            .Where(x => EF.Functions.Like(x.SubmissionPeriod, filter))
+            .AsAsyncEnumerable();
+
+        await foreach (var pom in poms)
+            yield return new PomResponse
+            {
+                SubmissionPeriod = pom.SubmissionPeriod!,
+                SubmissionPeriodDescription = pom.SubmissionPeriodDescription,
+                OrganisationId = pom.OrganisationId!.Value,
+                SubsidiaryId = pom.SubsidiaryId,
+                PackagingType = pom.PackagingType,
+                PackagingMaterial = pom.PackagingMaterial,
+                PackagingMaterialWeight = pom.PackagingMaterialWeight,
+                PackagingClass = pom.PackagingClass,
+                PackagingActivity = pom.PackagingActivity,
+                SubmitterId = pom.SubmitterId
+            };
+    }
+}

--- a/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/StreamPomsRequestValidator.cs
+++ b/src/EPR.CommonDataService.Api/Features/PayCal/Poms/StreamOut/StreamPomsRequestValidator.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation;
+
+namespace EPR.CommonDataService.Api.Features.PayCal.Poms.StreamOut;
+
+public sealed class StreamPomsRequestValidator
+    : AbstractValidator<StreamPomsRequest>
+{
+    public StreamPomsRequestValidator()
+    {
+        RuleFor(request => request.RelativeYear)
+            .NotNull()
+            .GreaterThanOrEqualTo(2025) // First valid EPR year
+            .LessThanOrEqualTo(9999);
+    }
+}

--- a/src/EPR.CommonDataService.Api/Infrastructure/NdJsonStreamResult.cs
+++ b/src/EPR.CommonDataService.Api/Infrastructure/NdJsonStreamResult.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+
+namespace EPR.CommonDataService.Api.Infrastructure;
+
+public static class NdJsonStreamOptions
+{
+    public static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+/// <summary>
+///     An ActionResult that streams NDJSON (newline-delimited JSON) data from an async enumerable source.
+/// </summary>
+/// <typeparam name="T">The type of objects to serialize and stream.</typeparam>
+public sealed class NdJsonStreamResult<T>
+    : IActionResult
+{
+    private readonly IAsyncEnumerable<T> _dataSource;
+    private readonly Action<Result>? _onComplete;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="NdJsonStreamResult{T}" /> class.
+    /// </summary>
+    /// <param name="dataSource">The async enumerable data source to stream.</param>
+    /// <param name="onComplete">Optional callback invoked when streaming completes, providing result summary.</param>
+    public NdJsonStreamResult(
+        IAsyncEnumerable<T> dataSource,
+        Action<Result>? onComplete = null)
+    {
+        _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+        _onComplete = onComplete;
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteResultAsync(ActionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var response = context.HttpContext.Response;
+        response.ContentType = "application/x-ndjson; charset=utf-8";
+        response.Headers[HeaderNames.CacheControl] = "no-store";
+        response.Headers["X-Accel-Buffering"] = "no";
+
+        await using var writer = new StreamWriter(response.Body, new UTF8Encoding(false), 16 * 1024, true);
+        writer.AutoFlush = false; // we'll flush manually after each record
+
+        var ct = context.HttpContext.RequestAborted;
+        var asyncEnumerable = _dataSource.WithCancellation(ct);
+        long count = 0;
+        var clientAborted = false;
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            await foreach (var record in asyncEnumerable)
+            {
+                var json = JsonSerializer.Serialize(record, NdJsonStreamOptions.JsonOptions);
+                await writer.WriteAsync(json);
+                await writer.WriteAsync('\n');
+
+                await writer.FlushAsync(ct); // flush writer to response body
+                await response.Body.FlushAsync(ct); // flush response body to the client
+
+                count++;
+            }
+        }
+        catch (Exception ex) when (ex is OperationCanceledException && ct.IsCancellationRequested)
+        {
+            clientAborted = true;
+        }
+        finally
+        {
+            sw.Stop();
+
+            _onComplete?.Invoke(new Result
+            {
+                WasAbortedByClient = clientAborted,
+                RecordsStreamed = count,
+                Duration = sw.Elapsed
+            });
+        }
+    }
+
+    public record Result
+    {
+        public required bool WasAbortedByClient { get; init; }
+        public required long RecordsStreamed { get; init; }
+        public required TimeSpan Duration { get; init; }
+    }
+}

--- a/src/EPR.CommonDataService.Api/Program.cs
+++ b/src/EPR.CommonDataService.Api/Program.cs
@@ -27,6 +27,8 @@ public static class Program
 
         var app = builder.Build();
 
+        app.UseResponseCompression();
+        app.UseRateLimiter();
         app.UseSwagger();
         app.UseSwaggerUI();
 

--- a/src/EPR.CommonDataService.Data/Entities/PayCalOrganisation.cs
+++ b/src/EPR.CommonDataService.Data/Entities/PayCalOrganisation.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Data.Entities;
+
+[ExcludeFromCodeCoverage]
+public record PayCalOrganisation
+{
+    public int? OrganisationId { get; init; }
+    public string? SubsidiaryId { get; init; }
+    public string? SubmitterId { get; init; }
+    public string? OrganisationName { get; init; }
+    public string? TradingName { get; init; }
+    public string? StatusCode { get; init; }
+    public string? LeaverDate { get; init; }
+    public string? JoinerDate { get; init; }
+    public string? ObligationStatus { get; init; }
+    public short? NumDaysObligated { get; init; }
+    public string? ErrorCode { get; init; }
+    public int? SubmissionPeriodYear { get; init; }
+}

--- a/src/EPR.CommonDataService.Data/Entities/PayCalPom.cs
+++ b/src/EPR.CommonDataService.Data/Entities/PayCalPom.cs
@@ -1,0 +1,19 @@
+﻿#nullable enable
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.CommonDataService.Data.Entities;
+
+[ExcludeFromCodeCoverage]
+public record PayCalPom
+{
+    public int? OrganisationId { get; init; }
+    public string? SubsidiaryId { get; init; }
+    public string? SubmitterId { get; init; }
+    public string? SubmissionPeriod { get; init; }
+    public string? SubmissionPeriodDescription { get; init; }
+    public string? PackagingActivity { get; init; }
+    public string? PackagingType { get; init; }
+    public string? PackagingClass { get; init; }
+    public string? PackagingMaterial { get; init; }
+    public double? PackagingMaterialWeight { get; init; }
+}

--- a/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
+++ b/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
@@ -26,6 +26,8 @@ public class SynapseContext : DbContext
     public DbSet<OrganisationRegistrationSummaryDataRow> OrganisationRegistrationSummaries { get; set; } = null!;
     public DbSet<OrganisationRegistrationDetailsDto> OrganisationRegistrationSubmissionDetails { get; set; } = null!;
     public DbSet<RegistrationFeeCalculationDetailsModel> RegistrationFeeCalculationDetailsModel { get; set; } = null!;
+    public DbSet<PayCalOrganisation> PayCalOrganisations { get; set; } = null!;
+    public DbSet<PayCalPom> PayCalPoms { get; set; } = null!;
 
     private const string InMemoryProvider = "Microsoft.EntityFrameworkCore.InMemory";
 
@@ -45,6 +47,50 @@ public class SynapseContext : DbContext
         var stringToGuidConverter = StringToGuidConverter.Get();
         var intToBoolConverter = IntToBoolConverter.Get();
         var stringToIntConverter = StringToIntConverter.Get();
+
+        modelBuilder.Entity<PayCalOrganisation>(entity =>
+        {
+            // Must have a key to allow inserts for unit tests
+            if (Database.ProviderName == InMemoryProvider)
+                entity.HasKey(e => new{e.SubmissionPeriodYear, e.OrganisationId});
+            else
+                entity.HasNoKey();
+
+            entity.ToTable("t_producer_obligation_determination", schema: "dbo");
+            entity.Property(e => e.OrganisationId).HasColumnName("organisation_id");
+            entity.Property(e => e.SubsidiaryId).HasColumnName("subsidiary_id").HasMaxLength(4000);
+            entity.Property(e => e.SubmitterId).HasColumnName("submitter_id").HasMaxLength(4000);
+            entity.Property(e => e.OrganisationName).HasColumnName("organisation_name").HasMaxLength(4000);
+            entity.Property(e => e.TradingName).HasColumnName("trading_name").HasMaxLength(4000);
+            entity.Property(e => e.StatusCode).HasColumnName("status_code").HasMaxLength(4000);
+            entity.Property(e => e.LeaverDate).HasColumnName("leaver_date").HasMaxLength(4000);
+            entity.Property(e => e.JoinerDate).HasColumnName("joiner_date").HasMaxLength(4000);
+            entity.Property(e => e.ObligationStatus).HasColumnName("obligation_status").HasMaxLength(1).IsFixedLength();
+            entity.Property(e => e.NumDaysObligated).HasColumnName("num_days_obligated");
+            entity.Property(e => e.ErrorCode).HasColumnName("error_code").HasMaxLength(4000);
+            entity.Property(e => e.SubmissionPeriodYear).HasColumnName("submission_period_year");
+        });
+
+        modelBuilder.Entity<PayCalPom>(entity =>
+        {
+            // Must have a key to allow inserts for unit tests
+            if (Database.ProviderName == InMemoryProvider)
+                entity.HasKey(e => new{e.SubmissionPeriod, e.OrganisationId, e.PackagingType, e.PackagingMaterial});
+            else
+                entity.HasNoKey();
+
+            entity.ToView("v_PayCal_Pom_MYC", schema: "dbo");
+            entity.Property(e => e.OrganisationId).HasColumnName("organisation_id");
+            entity.Property(e => e.SubsidiaryId).HasColumnName("subsidiary_id").HasMaxLength(4000);
+            entity.Property(e => e.SubmitterId).HasColumnName("submitter_id").HasMaxLength(4000);
+            entity.Property(e => e.SubmissionPeriod).HasColumnName("submission_period").HasMaxLength(4000);
+            entity.Property(e => e.SubmissionPeriodDescription).HasColumnName("submission_period_desc").HasMaxLength(4000);
+            entity.Property(e => e.PackagingActivity).HasColumnName("packaging_activity").HasMaxLength(4000);
+            entity.Property(e => e.PackagingType).HasColumnName("packaging_type").HasMaxLength(4000);
+            entity.Property(e => e.PackagingClass).HasColumnName("packaging_class").HasMaxLength(4000);
+            entity.Property(e => e.PackagingMaterial).HasColumnName("packaging_material").HasMaxLength(4000);
+            entity.Property(e => e.PackagingMaterialWeight).HasColumnName("packaging_material_weight");
+        });
 
         modelBuilder.Entity<PomSubmissionSummaryRow>()
             .Property(e => e.SubmissionId)

--- a/src/EPR.CommonDataService.Data/Infrastructure/TimeoutInterceptor.cs
+++ b/src/EPR.CommonDataService.Data/Infrastructure/TimeoutInterceptor.cs
@@ -1,0 +1,65 @@
+﻿using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EPR.CommonDataService.Data.Infrastructure;
+
+/// <summary>
+///     Intercepts database commands. If the command text contains a matching comment, it will override the timeout for
+///     that command.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class TimeoutInterceptor : DbCommandInterceptor
+{
+    public const string Trigger = "Use timeout: ";
+    private static readonly Regex Pattern = new(@$"^{Regex.Escape($"-- {Trigger}")}(\d+)",
+        RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
+
+    public override InterceptionResult<DbDataReader> ReaderExecuting(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result)
+    {
+        ManipulateCommand(command);
+        return result;
+    }
+
+    public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default)
+    {
+        ManipulateCommand(command);
+        return new ValueTask<InterceptionResult<DbDataReader>>(result);
+    }
+
+    private static void ManipulateCommand(DbCommand command)
+    {
+        var match = Pattern.Match(command.CommandText);
+
+        if (match.Success)
+        {
+            var timeout = int.Parse(match.Groups[1].Value);
+            command.CommandTimeout = timeout;
+        }
+    }
+}
+
+public static class TimeoutInterceptorExtensions
+{
+    /// <summary>
+    ///     Tags the IQueryable to be intercepted by <see cref="TimeoutInterceptor" />, effectively setting the
+    ///     underlying command timeout period to the specified value.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of entity being queried.</typeparam>
+    /// <param name="source">The source query.</param>
+    /// <param name="timeout">Timeout (will be rounded to seconds).</param>
+    /// <returns>A new query which is tagged to have a longer timeout applied.</returns>
+    public static IQueryable<TEntity> WithTimeout<TEntity>(this IQueryable<TEntity> source, TimeSpan timeout)
+    {
+        return source.TagWith($"{TimeoutInterceptor.Trigger}{timeout.TotalSeconds:0}");
+    }
+}


### PR DESCRIPTION
* feat(data): add entities and context configuration for PayCal data

* feat(data): Add TimeoutInterceptor for EF SQL command timeout management

* feat(api): Implement NdJsonStreamResult for streaming NDJSON responses

* feat(api): Enable gzip response compression for NDJSON

* build(api): add FluentValidation and EF Core InMemory dependencies

* feat(paycal): implement POM data streaming endpoint

* feat(paycal): implement organization data streaming endpoint

* feat(paycal): implement concurrent request limiter for streaming endpoints