### PR TITLE
Amcr 136 display closed loop recycling registration fee for large producers

### DIFF
--- a/src/EPR.CommonDataService.Data/Entities/OrganisationRegistrationDetailsDto.cs
+++ b/src/EPR.CommonDataService.Data/Entities/OrganisationRegistrationDetailsDto.cs
@@ -20,6 +20,7 @@ public class OrganisationRegistrationDetailsDto
     public string StatusPendingDate { get; set; }
     public string SubmittedDateTime { get; set; }
     public bool IsLateSubmission { get; set; }
+    public bool IsClosedLoopRecycler { get; set; }
     public string SubmissionPeriod { get; set; }
     public int RelevantYear { get; set; }
     public string ResubmissionFileId { get; set; }

--- a/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
+++ b/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
@@ -191,6 +191,7 @@ public class SynapseContext : DbContext
         
         modelBuilder.Entity<OrganisationRegistrationDetailsDto>()
             .Property(e => e.IsClosedLoopRecycler)
+            .HasColumnName("ClosedLoopRegistration")
             .HasConversion(intToBoolConverter);
     }
 

--- a/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
+++ b/src/EPR.CommonDataService.Data/Infrastructure/SynapseContext.cs
@@ -188,6 +188,10 @@ public class SynapseContext : DbContext
         modelBuilder.Entity<PomSubmissionSummaryRow>()
             .Property(e => e.SubmissionId)
             .HasConversion(stringToGuidConverter);
+        
+        modelBuilder.Entity<OrganisationRegistrationDetailsDto>()
+            .Property(e => e.IsClosedLoopRecycler)
+            .HasConversion(intToBoolConverter);
     }
 
     private void BuildComplexEntities(ModelBuilder modelBuilder)

--- a/src/EPR.CommonDataService.Data/Scripts/Create Tables/create-apps-fetchorgregdetails-table.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Create Tables/create-apps-fetchorgregdetails-table.sql
@@ -61,7 +61,8 @@ BEGIN
 		[BrandsBlobName] [nvarchar](4000) NULL,
 		[ComplianceSchemeId] [nvarchar](4000) NULL,
 		[CSId] [nvarchar](4000) NULL,
-		[CSOJson] [nvarchar](max) NULL
+		[CSOJson] [nvarchar](max) NULL,
+		[ClosedLoopRegistration] [bit]
 	)
 	WITH
 	(

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/execute-merge-submissions-rpd-to-apps-schema.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/execute-merge-submissions-rpd-to-apps-schema.sql
@@ -23,82 +23,6 @@ select @batch_id  = ISNULL(max(batch_id),0)+1 from [dbo].[batch_log]
 --New changes for the table = t_FetchOrganisationRegistrationSubmissionDetails_resub  from view = V_FetchOrganisationRegistrationSubmissionDetails_resub
 
 		set @start_dt = getdate()
-		IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[t_FetchOrganisationRegistrationSubmissionDetails_resub]') AND type in (N'U'))
-		BEGIN
-			CREATE TABLE [dbo].[t_FetchOrganisationRegistrationSubmissionDetails_resub]
-			(
-			[SubmissionId] [nvarchar](4000) NULL,
-			[OrganisationId] [nvarchar](4000) NULL,
-			[OrganisationName] [nvarchar](4000) NULL,
-			[OrganisationReference] [nvarchar](20) NULL,
-			[ApplicationReferenceNumber] [nvarchar](4000) NULL,
-			[RegistrationReferenceNumber] [nvarchar](4000) NULL,
-			[SubmissionStatus] [nvarchar](4000) NULL,
-			[StatusPendingDate] [nvarchar](4000) NULL,
-			[SubmittedDateTime] [nvarchar](4000) NULL,
-			[IsLateSubmission] [bit] NULL,
-			[IsResubmission] [bit] NULL,
-			[ResubmissionStatus] [nvarchar](4000) NULL,
-			[RegistrationDate] [nvarchar](4000) NULL,
-			[ResubmissionDate] [nvarchar](4000) NULL,
-			[ResubmissionFileId] [nvarchar](4000) NULL,
-			[SubmissionPeriod] [nvarchar](4000) NULL,
-			[RelevantYear] [int] NULL,
-			[IsComplianceScheme] [bit] NULL,
-			[OrganisationSize] [varchar](5) NULL,
-			[OrganisationType] [varchar](10) NULL,
-			[NationId] [int] NULL,
-			[NationCode] [varchar](6) NULL,
-			[RegulatorComment] [nvarchar](4000) NULL,
-			[ProducerComment] [nvarchar](4000) NULL,
-			[RegulatorDecisionDate] [nvarchar](4000) NULL,
-			[RegulatorResubmissionDecisionDate] [nvarchar](4000) NULL,
-			[RegulatorUserId] [nvarchar](4000) NULL,
-			[CompaniesHouseNumber] [nvarchar](4000) NULL,
-			[BuildingName] [nvarchar](4000) NULL,
-			[SubBuildingName] [nvarchar](4000) NULL,
-			[BuildingNumber] [nvarchar](4000) NULL,
-			[Street] [nvarchar](4000) NULL,
-			[Locality] [nvarchar](4000) NULL,
-			[DependentLocality] [nvarchar](4000) NULL,
-			[Town] [nvarchar](4000) NULL,
-			[County] [nvarchar](4000) NULL,
-			[Country] [nvarchar](4000) NULL,
-			[Postcode] [nvarchar](4000) NULL,
-			[SubmittedUserId] [nvarchar](4000) NULL,
-			[FirstName] [nvarchar](4000) NULL,
-			[LastName] [nvarchar](4000) NULL,
-			[Email] [nvarchar](4000) NULL,
-			[Telephone] [nvarchar](4000) NULL,
-			[ServiceRole] [nvarchar](100) NULL,
-			[ServiceRoleId] [int] NULL,
-			[IsOnlineMarketplace] [bit] NULL,
-			[NumberOfSubsidiaries] [int] NOT NULL,
-			[NumberOfOnlineSubsidiaries] [int] NOT NULL,
-			[CompanyDetailsFileId] [nvarchar](4000) NULL,
-			[CompanyDetailsFileName] [nvarchar](4000) NULL,
-			[CompanyDetailsBlobName] [nvarchar](4000) NULL,
-			[PartnershipFileId] [nvarchar](4000) NULL,
-			[PartnershipFileName] [nvarchar](4000) NULL,
-			[PartnershipBlobName] [nvarchar](4000) NULL,
-			[BrandsFileId] [nvarchar](4000) NULL,
-			[BrandsFileName] [nvarchar](4000) NULL,
-			[BrandsBlobName] [nvarchar](4000) NULL,
-			[ComplianceSchemeId] [nvarchar](4000) NULL,
-			[CSId] [nvarchar](4000) NULL,
-			[CSOJson] [nvarchar](max) NULL
-			)
-			WITH
-			(
-			DISTRIBUTION = HASH ( [SubmissionId] ),
-			HEAP
-			);
-			insert into dbo.t_FetchOrganisationRegistrationSubmissionDetails_resub 
-			select * from dbo.V_FetchOrganisationRegistrationSubmissionDetails_resub;
-			INSERT INTO [dbo].[batch_log] ([ID],[ProcessName],[SubProcessName],[Count],[start_time_stamp],[end_time_stamp],[Comments],batch_id)
-			select (select ISNULL(max(id),1)+1 from [dbo].[batch_log]),'sp_MergeSubmissionsSummaries','create t_FetchOrganisationRegistrationSubmissionDetails_resub', NULL, @start_dt, getdate(), 'Completed',@batch_id
-		END;	
-		ELSE
 		BEGIN
 
 			set @start_dt = getdate()
@@ -188,6 +112,7 @@ select @batch_id  = ISNULL(max(batch_id),0)+1 from [dbo].[batch_log]
 			,Target.[ComplianceSchemeId]				= Source.[ComplianceSchemeId]
 			,Target.[CSId]								= Source.[CSId]
 			,Target.[CSOJson]							= Source.[CSOJson]
+			,Target.[ClosedLoopRegistration]			= Source.[ClosedLoopRegistration]
 
 			WHEN NOT MATCHED BY TARGET THEN
 		INSERT (
@@ -251,6 +176,7 @@ select @batch_id  = ISNULL(max(batch_id),0)+1 from [dbo].[batch_log]
       ,[ComplianceSchemeId]
       ,[CSId]
       ,[CSOJson]
+      ,[ClosedLoopRegistration]
 	)
 	VALUES (
 		Source.[SubmissionId]
@@ -313,6 +239,7 @@ select @batch_id  = ISNULL(max(batch_id),0)+1 from [dbo].[batch_log]
 		,Source.[ComplianceSchemeId]
 		,Source.[CSId]
 		,Source.[CSOJson]
+		,Source.[ClosedLoopRegistration]
 		)
 	    WHEN NOT MATCHED BY SOURCE THEN
         DELETE; -- delete from table when no longer in source

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_FetchOrganisationRegistrationSubmissionDetails_resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_FetchOrganisationRegistrationSubmissionDetails_resub.sql
@@ -68,7 +68,7 @@ BEGIN
            o.CSId,
            o.CSOJson,
            s.RegistrationJourney,
-           o.ClosedLoopRegistration
+           o.ClosedLoopRegistration AS IsClosedLoopRecycler
 	from dbo.t_FetchOrganisationRegistrationSubmissionDetails_resub o
     join apps.Submissions s on s.SubmissionId = o.SubmissionId
     where o.SubmissionId = @SubmissionId;

--- a/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_FetchOrganisationRegistrationSubmissionDetails_resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Stored Procedures/sp_FetchOrganisationRegistrationSubmissionDetails_resub.sql
@@ -67,7 +67,8 @@ BEGIN
            o.ComplianceSchemeId,
            o.CSId,
            o.CSOJson,
-           s.RegistrationJourney
+           s.RegistrationJourney,
+           o.ClosedLoopRegistration
 	from dbo.t_FetchOrganisationRegistrationSubmissionDetails_resub o
     join apps.Submissions s on s.SubmissionId = o.SubmissionId
     where o.SubmissionId = @SubmissionId;

--- a/src/EPR.CommonDataService.Data/Scripts/Views/v_FetchOrganisationRegistrationSubmissionDetails_resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/v_FetchOrganisationRegistrationSubmissionDetails_resub.sql
@@ -200,7 +200,7 @@ InitialSubmissionCTE AS (
             CASE
                 WHEN cd.closed_loop_registration = 'yes' THEN 1
                 ELSE 0
-            END AS closed_loop_registration,
+            END AS ClosedLoopRegistration,
             Row_number() OVER (
                 PARTITION BY rse.submissionid ORDER BY RowNum ASC
             ) AS RowNumber
@@ -352,7 +352,7 @@ SubmissionStatusCTE AS (
             COALESCE(rd.UserId, id.UserId) AS RegulatorUserId,
             COALESCE(r.UserId, s.UserId) AS LatestProducerUserId,
             reg.RegistrationReferenceNumber,
-            s.closed_loop_registration,
+            s.ClosedLoopRegistration,
             -- row number to emulate TOP1 for each submission id by rd.DecisionDate aka ResubmissionDecisionDate as per the original query
             Row_number() OVER (PARTITION BY s.submissionid ORDER BY rd.DecisionDate DESC) AS RowNumber
         FROM InitialSubmissionCTE s
@@ -538,7 +538,7 @@ SubmissionDetails AS (
             ss.LatestProducerUserId AS SubmittedUserId,
             s.ComplianceSchemeId,
             d.ComplianceSchemeId AS CSId,
-            ss.closed_loop_registration,
+            ss.ClosedLoopRegistration,
             ROW_NUMBER() OVER (
                 PARTITION BY s.OrganisationId,
                 s.SubmissionPeriod,
@@ -792,7 +792,7 @@ SELECT DISTINCT r.SubmissionId,
     r.ComplianceSchemeId,
     r.CSId,
     acpp.FinalJson AS CSOJson,
-    r.closed_loop_registration
+    r.ClosedLoopRegistration
 FROM SubmissionDetails r
 INNER JOIN [rpd].[Organisations] o ON o.ExternalId = r.OrganisationId
 LEFT JOIN AllCompliancePaycalParametersAsJSONCTE acpp ON acpp.CSOReference = o.ReferenceNumber

--- a/src/EPR.CommonDataService.Data/Scripts/Views/v_FetchOrganisationRegistrationSubmissionDetails_resub.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/v_FetchOrganisationRegistrationSubmissionDetails_resub.sql
@@ -197,6 +197,10 @@ InitialSubmissionCTE AS (
     FROM (
         SELECT rse.*,
             cd.organisation_size,
+            CASE
+                WHEN cd.closed_loop_registration = 'yes' THEN 1
+                ELSE 0
+            END AS closed_loop_registration,
             Row_number() OVER (
                 PARTITION BY rse.submissionid ORDER BY RowNum ASC
             ) AS RowNumber
@@ -348,6 +352,7 @@ SubmissionStatusCTE AS (
             COALESCE(rd.UserId, id.UserId) AS RegulatorUserId,
             COALESCE(r.UserId, s.UserId) AS LatestProducerUserId,
             reg.RegistrationReferenceNumber,
+            s.closed_loop_registration,
             -- row number to emulate TOP1 for each submission id by rd.DecisionDate aka ResubmissionDecisionDate as per the original query
             Row_number() OVER (PARTITION BY s.submissionid ORDER BY rd.DecisionDate DESC) AS RowNumber
         FROM InitialSubmissionCTE s
@@ -533,6 +538,7 @@ SubmissionDetails AS (
             ss.LatestProducerUserId AS SubmittedUserId,
             s.ComplianceSchemeId,
             d.ComplianceSchemeId AS CSId,
+            ss.closed_loop_registration,
             ROW_NUMBER() OVER (
                 PARTITION BY s.OrganisationId,
                 s.SubmissionPeriod,
@@ -785,7 +791,8 @@ SELECT DISTINCT r.SubmissionId,
     r.BrandsBlobName,
     r.ComplianceSchemeId,
     r.CSId,
-    acpp.FinalJson AS CSOJson
+    acpp.FinalJson AS CSOJson,
+    r.closed_loop_registration
 FROM SubmissionDetails r
 INNER JOIN [rpd].[Organisations] o ON o.ExternalId = r.OrganisationId
 LEFT JOIN AllCompliancePaycalParametersAsJSONCTE acpp ON acpp.CSOReference = o.ReferenceNumber


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/AMCR-136

This change implements AMCR-136 by surfacing closed-loop recycler registration fee context on organisation registration submission details returned from Common Data.

- `IsClosedLoopRecycler` is added to `OrganisationRegistrationDetailsDto`, mapped from the Synapse column `ClosedLoopRegistration` with `int` → `bool` conversion in `SynapseContext`.
- Database artefacts (`t_FetchOrganisationRegistrationSubmissionDetails_resub`, `V_FetchOrganisationRegistrationSubmissionDetails_resub`, `sp_FetchOrganisationRegistrationSubmissionDetails_resub`, `sp_MergeSubmissionsSummaries`, and related `apps/RPD scripts`) are updated so that flag is populated and kept in sync through the submission merge path.
- `sp_FetchOrganisationRegistrationSubmissionDetails_resub` is enhanced (including join to `OrgRegistrationSummaries` / `OrgRegistrationsSummaries` and `RegistrationJourney` mapping) so the proc returns consistent registration journey and closed-loop data.