### PR TITLE
ELS-344 correct SubmittedDate for Pom Resubmissions

### DIFF
--- a/src/EPR.CommonDataService.Data/Scripts/Views/create-submissions-summaries-view.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/create-submissions-summaries-view.sql
@@ -110,7 +110,7 @@ AS WITH
                 ) AS RowNum
             FROM apps.SubmissionEvents se
             INNER JOIN ResubmissionApplicationSubmittedData rad
-                ON rad.FileId = se.FileId AND rad.SubmissionId = se.SubmissionId
+                ON rad.FileId = se.FileId
             WHERE se.[Type] = 'PackagingResubmissionApplicationSubmitted'
         )
 

--- a/src/EPR.CommonDataService.Data/Scripts/Views/create-submissions-summaries-view.sql
+++ b/src/EPR.CommonDataService.Data/Scripts/Views/create-submissions-summaries-view.sql
@@ -1,4 +1,4 @@
-﻿IF EXISTS (SELECT 1 FROM sys.views WHERE object_id = OBJECT_ID(N'[apps].[v_SubmissionsSummaries]'))
+IF EXISTS (SELECT 1 FROM sys.views WHERE object_id = OBJECT_ID(N'[apps].[v_SubmissionsSummaries]'))
 DROP VIEW [apps].[v_SubmissionsSummaries];
 GO
 
@@ -97,6 +97,28 @@ AS WITH
             FROM AllSubmittedEventsCTE
             WHERE RowNum = 1
         )
+
+        , ResubmissionApplicationSubmittedDate AS (
+            SELECT
+                se.FileId,
+                se.SubmissionId,
+                se.Created AS ResubmissionSubmittedDate,
+                se.UserId AS ResubmissionSubmittedUserId,
+                ROW_NUMBER() OVER (
+                    PARTITION BY se.FileId
+                    ORDER BY se.load_ts DESC  -- deduplicate cosmos sync duplicates
+                ) AS RowNum
+            FROM apps.SubmissionEvents se
+            INNER JOIN ResubmissionApplicationSubmittedData rad
+                ON rad.FileId = se.FileId AND rad.SubmissionId = se.SubmissionId
+            WHERE se.[Type] = 'PackagingResubmissionApplicationSubmitted'
+        )
+
+        , LatestResubmissionApplicationSubmittedDate AS (
+            SELECT FileId, SubmissionId, ResubmissionSubmittedDate, ResubmissionSubmittedUserId
+            FROM ResubmissionApplicationSubmittedDate
+            WHERE RowNum = 1
+        )
 		
     -- Get Decision events for submitted (match by fileId)
         ,AllRelatedDecisionEventsCTE AS (
@@ -132,18 +154,21 @@ AS WITH
         WHERE RowNum = 1
         )
 
-        ,JoinedSubmittedAndDecisionsCTE AS (
-        SELECT
-        submitted.SubmissionId,
-        submitted.SubmittedDate,
-        submitted.FileId,
-		submitted.SubmittedUserId,
-        decision.DecisionDate,
-        decision.Decision,
-        decision.Comments,
-        decision.IsResubmissionRequired
-        FROM LatestSubmittedEventsCTE submitted
-        LEFT JOIN LatestRelatedDecisionEventsCTE decision ON decision.FileId = submitted.FileId
+        , JoinedSubmittedAndDecisionsCTE AS (
+            SELECT
+                submitted.SubmissionId,
+                -- If a resubmission application was submitted, use that date; otherwise original submitted date
+                ISNULL(resub.ResubmissionSubmittedDate, submitted.SubmittedDate) AS SubmittedDate,
+                submitted.FileId,
+                ISNULL(resub.ResubmissionSubmittedUserId, submitted.SubmittedUserId) AS SubmittedUserId,
+                decision.DecisionDate,
+                decision.Decision,
+                decision.Comments,
+                decision.IsResubmissionRequired
+            FROM LatestSubmittedEventsCTE submitted
+            LEFT JOIN LatestResubmissionApplicationSubmittedDate resub
+                ON resub.FileId = submitted.FileId AND resub.SubmissionId = submitted.SubmissionId
+            LEFT JOIN LatestRelatedDecisionEventsCTE decision ON decision.FileId = submitted.FileId
         )
 
         ,AllRelatedSubmissionsCTE AS (


### PR DESCRIPTION
An incident (INC2476638) has been raised by the regulators. For resubmissions where the file was uploaded and submitted on different days - the SubmittedDate in the regulator portal is incorrectly showing as the uploaded date.

This change is to take into account the timestamp of the `PackagingResubmissionApplicationSubmitted` event when deducing the SubmittedDate from the submission events.